### PR TITLE
Agregar CRUD de Proveedor

### DIFF
--- a/controladores/proveedor.php
+++ b/controladores/proveedor.php
@@ -1,0 +1,54 @@
+<?php
+
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    $json_datos = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO `proveedor`(`nombre_proveedor`, `ruc`, `telefono`, `estado`) VALUES (:nombre_proveedor,:ruc,:telefono,:estado)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer_proveedor'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_proveedor`, `nombre_proveedor`, `ruc`, `telefono`, `estado` FROM `proveedor`");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['leer_proveedor_id'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_proveedor`, `nombre_proveedor`, `ruc`, `telefono`, `estado` FROM `proveedor` WHERE id_proveedor = :id");
+    $query->execute([
+        "id" => $_POST['leer_proveedor_id']
+    ]);
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
+
+function actualizar($lista)
+{
+    $json_datos = json_decode($lista, true);
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("UPDATE `proveedor` SET `nombre_proveedor`=:nombre_proveedor,`ruc`=:ruc,`telefono`=:telefono,`estado`=:estado WHERE `id_proveedor`=:id_proveedor");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("DELETE FROM `proveedor` WHERE `id_proveedor`= :id");
+    $query->execute([
+        "id" => $_POST['eliminar']
+    ]);
+}

--- a/index.php
+++ b/index.php
@@ -337,6 +337,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                             <p>Producto</p>
                                         </a>
                                     </li>
+                                    <li class="nav-item">
+                                        <a href="#" onclick="mostrarListarProveedor();" class="nav-link">
+                                            <i class="nav-icon bi bi-circle"></i>
+                                            <p>Proveedor</p>
+                                        </a>
+                                    </li>
                                 </ul>
                             </li>
                             <li class="nav-item menu-open">
@@ -664,6 +670,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/equipo.js"></script>
         <script src="vistas/cliente_equipo.js"></script>
         <script src="vistas/producto.js"></script>
+        <script src="vistas/proveedor.js"></script>
         <script src="vistas/recepcion.js"></script>
         <!--end::Script-->
     </body>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -130,6 +130,20 @@ CREATE TABLE `producto` (
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `proveedor`
+--
+
+CREATE TABLE `proveedor` (
+  `id_proveedor` int(11) NOT NULL,
+  `nombre_proveedor` varchar(100) DEFAULT NULL,
+  `ruc` varchar(45) DEFAULT NULL,
+  `telefono` varchar(45) DEFAULT NULL,
+  `estado` varchar(45) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `marca`
 --
 
@@ -268,6 +282,12 @@ ALTER TABLE `producto`
   ADD PRIMARY KEY (`id_producto`);
 
 --
+-- Indices de la tabla `proveedor`
+--
+ALTER TABLE `proveedor`
+  ADD PRIMARY KEY (`id_proveedor`);
+
+--
 -- Indices de la tabla `marca`
 --
 ALTER TABLE `marca`
@@ -331,6 +351,12 @@ ALTER TABLE `equipo`
 --
 ALTER TABLE `producto`
   MODIFY `id_producto` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=4;
+
+--
+-- AUTO_INCREMENT de la tabla `proveedor`
+--
+ALTER TABLE `proveedor`
+  MODIFY `id_proveedor` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 
 --
 -- AUTO_INCREMENT de la tabla `marca`

--- a/paginas/referenciales/proveedor/agregar.php
+++ b/paginas/referenciales/proveedor/agregar.php
@@ -1,0 +1,44 @@
+<?php session_start(); ?>
+<div class="container mt-4 p-4 shadow rounded bg-light" style="max-width: 950px;">
+    <input type="hidden" id="id_proveedor" value="0">
+
+    <div class="text-center mb-4">
+        <h2 class="fw-bold text-primary">Nuevo Proveedor</h2>
+        <hr>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-6">
+            <label for="nombre_proveedor" class="form-label fs-5">Nombre</label>
+            <input type="text" id="nombre_proveedor" class="form-control form-control-lg" placeholder="Ingrese el nombre">
+        </div>
+        <div class="col-md-6">
+            <label for="ruc" class="form-label fs-5">RUC</label>
+            <input type="text" id="ruc" class="form-control form-control-lg" placeholder="Ingrese el RUC">
+        </div>
+        <div class="col-md-6">
+            <label for="telefono" class="form-label fs-5">Teléfono</label>
+            <input type="text" id="telefono" class="form-control form-control-lg" placeholder="Ingrese el teléfono">
+        </div>
+        <div class="col-md-6">
+            <label for="estado" class="form-label fs-5">Estado</label>
+            <select id="estado" class="form-select form-select-lg">
+                <option value="ACTIVO">ACTIVO</option>
+                <option value="INACTIVO">INACTIVO</option>
+            </select>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-md-6">
+            <button class="btn btn-success btn-lg w-100" onclick="guardarProveedor();">
+                <i class="bi bi-check-circle"></i> Guardar
+            </button>
+        </div>
+        <div class="col-md-6">
+            <button class="btn btn-outline-danger btn-lg w-100" onclick="mostrarListarProveedor();">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>

--- a/paginas/referenciales/proveedor/listar.php
+++ b/paginas/referenciales/proveedor/listar.php
@@ -1,0 +1,30 @@
+<div class="container-fluid mt-4 p-4 shadow rounded bg-white">
+    <div class="row align-items-center mb-3">
+        <div class="col-md-8">
+            <h2 class="fw-bold text-secondary mb-0">📦 Lista de Proveedores</h2>
+        </div>
+        <div class="col-md-4 text-md-end text-start mt-3 mt-md-0">
+            <button class="btn btn-primary btn-lg" onclick="mostrarAgregarProveedor(); return false;">
+                <i class="bi bi-plus-circle"></i> Agregar Proveedor
+            </button>
+        </div>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-hover table-bordered align-middle text-center fs-5">
+            <thead class="table-dark text-white">
+                <tr>
+                    <th style="min-width: 50px;">#</th>
+                    <th style="min-width: 150px;">Nombre</th>
+                    <th style="min-width: 100px;">RUC</th>
+                    <th style="min-width: 100px;">Teléfono</th>
+                    <th style="min-width: 100px;">Estado</th>
+                    <th style="min-width: 180px;">Operaciones</th>
+                </tr>
+            </thead>
+            <tbody id="proveedor_tb">
+                <!-- Se cargan los proveedores aquí -->
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/vistas/proveedor.js
+++ b/vistas/proveedor.js
@@ -1,0 +1,99 @@
+//mostrar Lista
+function mostrarListarProveedor() {
+    let contenido = dameContenido("paginas/referenciales/proveedor/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaProveedor();
+}
+
+//Mostrar Agregar
+function mostrarAgregarProveedor() {
+    let contenido = dameContenido("paginas/referenciales/proveedor/agregar.php");
+    $("#contenido-principal").html(contenido);
+}
+
+//Guardar
+function guardarProveedor(){
+    if($("#nombre_proveedor").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debes de ingresar un nombre", "ERROR");
+        return;
+    }
+    if($("#ruc").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debes de ingresar un RUC", "ERROR");
+        return;
+    }
+    if($("#telefono").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debes de ingresar un teléfono", "ERROR");
+        return;
+    }
+
+    let data = {
+        'nombre_proveedor': $("#nombre_proveedor").val(),
+        'ruc': $("#ruc").val(),
+        'telefono': $("#telefono").val(),
+        'estado': $("#estado").val()
+    };
+
+    if($("#id_proveedor").val() === "0"){
+        ejecutarAjax("controladores/proveedor.php", "guardar="+JSON.stringify(data));
+        mensaje_dialogo_info("Guardado correctamente");
+    }else{
+        data = {...data, "id_proveedor": $("#id_proveedor").val()};
+        ejecutarAjax("controladores/proveedor.php", "actualizar="+JSON.stringify(data));
+        mensaje_dialogo_info("Actualizado Correctamente");
+        $("#id_proveedor").val("0");
+    }
+    mostrarListarProveedor();
+}
+
+$(document).on("click", ".eliminar-proveedor", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    $.ajax({
+        type: "POST",
+        async: false,
+        cache: false,
+        url: "controladores/proveedor.php",
+        data: "eliminar="+id,
+        success: function(){
+            mensaje_dialogo_info("Eliminado");
+            cargarTablaProveedor();
+        }
+    });
+});
+
+$(document).on("click", ".editar-proveedor", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    let contenido = dameContenido("paginas/referenciales/proveedor/agregar.php");
+    $("#contenido-principal").html(contenido);
+    let data = ejecutarAjax("controladores/proveedor.php", "leer_proveedor_id="+id);
+    let json_data = JSON.parse(data);
+    $("#nombre_proveedor").val(json_data.nombre_proveedor);
+    $("#ruc").val(json_data.ruc);
+    $("#telefono").val(json_data.telefono);
+    $("#estado").val(json_data.estado);
+    $("#id_proveedor").val(id);
+});
+
+function cargarTablaProveedor(){
+    let data = ejecutarAjax("controladores/proveedor.php", "leer_proveedor=1");
+    if(data === "0"){
+        $("#proveedor_tb").html("");
+    }else{
+        let json_data = JSON.parse(data);
+        $("#proveedor_tb").html("");
+        json_data.map(function(item){
+            $("#proveedor_tb").append(`
+                <tr>
+                    <td>${item.id_proveedor}</td>
+                    <td>${item.nombre_proveedor}</td>
+                    <td>${item.ruc}</td>
+                    <td>${item.telefono}</td>
+                    <td>${item.estado}</td>
+                    <td>
+                        <button class="btn btn-warning editar-proveedor">Editar</button>
+                        <button class="btn btn-danger eliminar-proveedor">Eliminar</button>
+                    </td>
+                </tr>
+            `);
+        });
+    }
+}


### PR DESCRIPTION
## Resumen
- Añadido módulo de proveedores dentro de Referencial.
- Implementadas vistas, controlador y JavaScript para CRUD de proveedores.
- Actualizado el script SQL con la tabla `proveedor` e índices.

## Testing
- `php -l index.php`
- `php -l controladores/proveedor.php`
- `php -l paginas/referenciales/proveedor/agregar.php`
- `php -l paginas/referenciales/proveedor/listar.php`
- `node --check vistas/proveedor.js`


------
https://chatgpt.com/codex/tasks/task_e_688fdaf33b2c8333a64127dbba4d0f19