### PR TITLE
fix: handle optional auditoria in compra controller

### DIFF
--- a/controladores/compra.php
+++ b/controladores/compra.php
@@ -1,6 +1,10 @@
 <?php
 require_once '../conexion/db.php';
-require_once 'auditoria.php';
+// Auditoría opcional: si el archivo existe se carga para registrar acciones,
+// de lo contrario se continúa sin interrumpir el flujo de la aplicación.
+if (file_exists(__DIR__ . '/auditoria.php')) {
+    require_once __DIR__ . '/auditoria.php';
+}
 
 if(isset($_POST['leer'])){
     $conexion = new DB();


### PR DESCRIPTION
## Summary
- Avoid fatal errors in purchase module by conditionally loading `auditoria.php`

## Testing
- `php -l controladores/compra.php`
- `php -r 'chdir("controladores"); $_POST["leer"]=1; include "compra.php";'` *(fails: Error connection: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688fec68e1ec83338b7238069050fc63