### PR TITLE
Add diagnostico service CRUD

### DIFF
--- a/controladores/diagnostico.php
+++ b/controladores/diagnostico.php
@@ -1,0 +1,66 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['leer_recepcion'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT rc.id_recepcion_cabecera, rc.fecha, CONCAT(c.nombre, ' ', c.apellido) AS cliente FROM recepcion_cabecera rc JOIN cliente c ON rc.id_cliente = c.id_cliente WHERE rc.estado <> 'ANULADO'");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['guardar'])) {
+    $json_datos = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO diagnostico_cabecera (id_recepcion_cabecera, fecha_diagnostico, id_tecnico, costo_estimado, estado_diagnostico, observaciones) VALUES (:id_recepcion_cabecera, :fecha_diagnostico, :id_tecnico, :costo_estimado, :estado_diagnostico, :observaciones)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['guardar_detalle'])) {
+    $json_datos = json_decode($_POST['guardar_detalle'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO diagnostico_detalle (id_diagnostico, descripcion_prueba, resultado, observaciones) VALUES (:id_diagnostico, :descripcion_prueba, :resultado, :observaciones)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['dameUltimoID'])) {
+    dameUltimoID();
+}
+
+function dameUltimoID() {
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("SELECT MAX(id_diagnostico) AS id_diagnostico FROM diagnostico_cabecera");
+    $query->execute();
+    if ($query->rowCount()) {
+        foreach ($query as $fila) {
+            echo $fila['id_diagnostico'];
+        }
+    } else {
+        echo '0';
+    }
+}
+
+if (isset($_POST['leer_diagnostico'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT dc.id_diagnostico, dc.fecha_diagnostico, dc.costo_estimado, dc.estado_diagnostico, rc.id_recepcion_cabecera FROM diagnostico_cabecera dc JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['anular'])) {
+    anular($_POST['anular']);
+}
+
+function anular($id) {
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("UPDATE diagnostico_cabecera SET estado_diagnostico = 'ANULADO' WHERE id_diagnostico = $id");
+    $query->execute();
+}
+?>

--- a/index.php
+++ b/index.php
@@ -399,6 +399,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                             <p>Recepción</p>
                                         </a>
                                     </li>
+                                    <li class="nav-item">
+                                        <a href="#" onclick="mostrarListarDiagnostico();" class="nav-link">
+                                            <i class="nav-icon bi bi-circle"></i>
+                                            <p>Diagnóstico</p>
+                                        </a>
+                                    </li>
                                 </ul>
                             </li>
 
@@ -710,6 +716,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/producto.js"></script>
         <script src="vistas/proveedor.js"></script>
         <script src="vistas/recepcion.js"></script>
+        <script src="vistas/diagnostico.js"></script>
         <script src="vistas/pedido_proveedor.js"></script>
         <script src="vistas/presupuesto.js"></script>
         <script src="vistas/orden_compra.js"></script>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -667,6 +667,54 @@ ALTER TABLE `recepcion_detalle`
   MODIFY `id_recepcion_detalle` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=16;
 
 --
+-- Estructura de tabla para la tabla `diagnostico_cabecera`
+--
+CREATE TABLE `diagnostico_cabecera` (
+  `id_diagnostico` int(11) NOT NULL,
+  `id_recepcion_cabecera` int(11) NOT NULL,
+  `fecha_diagnostico` datetime NOT NULL,
+  `id_tecnico` int(11) DEFAULT NULL,
+  `costo_estimado` decimal(10,2) DEFAULT 0,
+  `estado_diagnostico` varchar(20) DEFAULT 'Pendiente',
+  `observaciones` text
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- Estructura de tabla para la tabla `diagnostico_detalle`
+--
+CREATE TABLE `diagnostico_detalle` (
+  `id_diagnostico_detalle` int(11) NOT NULL,
+  `id_diagnostico` int(11) NOT NULL,
+  `descripcion_prueba` varchar(200) DEFAULT NULL,
+  `resultado` varchar(100) DEFAULT NULL,
+  `observaciones` text
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+--
+-- Indices de la tabla `diagnostico_cabecera`
+--
+ALTER TABLE `diagnostico_cabecera`
+  ADD PRIMARY KEY (`id_diagnostico`);
+
+--
+-- Indices de la tabla `diagnostico_detalle`
+--
+ALTER TABLE `diagnostico_detalle`
+  ADD PRIMARY KEY (`id_diagnostico_detalle`);
+
+--
+-- AUTO_INCREMENT de la tabla `diagnostico_cabecera`
+--
+ALTER TABLE `diagnostico_cabecera`
+  MODIFY `id_diagnostico` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT de la tabla `diagnostico_detalle`
+--
+ALTER TABLE `diagnostico_detalle`
+  MODIFY `id_diagnostico_detalle` int(11) NOT NULL AUTO_INCREMENT;
+
+--
 -- AUTO_INCREMENT de la tabla `servicio`
 --
 ALTER TABLE `servicio`

--- a/paginas/movimientos/servicios/diagnostico/agregar.php
+++ b/paginas/movimientos/servicios/diagnostico/agregar.php
@@ -1,0 +1,87 @@
+<?php
+session_start();
+?>
+<div class="container mt-5">
+    <div class="card shadow-lg rounded-4 p-5 bg-white">
+        <h3 class="mb-4 text-primary fw-bold">NUEVO DIAGNÓSTICO</h3>
+        <hr>
+
+        <form id="formDiagnostico" onsubmit="return false;">
+            <div class="row g-4 mb-4">
+                <div class="col-md-3">
+                    <label for="fecha" class="form-label fw-semibold text-dark">Fecha <span class="text-danger">*</span></label>
+                    <input type="date" id="fecha" class="form-control" required />
+                </div>
+                <div class="col-md-3">
+                    <label for="recepcion_lst" class="form-label fw-semibold text-dark">Recepción <span class="text-danger">*</span></label>
+                    <select id="recepcion_lst" class="form-select" required>
+                        <option value="0">-- Seleccione una recepción --</option>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label for="costo_estimado" class="form-label fw-semibold text-dark">Costo Estimado</label>
+                    <input type="number" step="0.01" id="costo_estimado" class="form-control" value="0" />
+                </div>
+                <div class="col-md-3">
+                    <label for="observaciones" class="form-label fw-semibold text-dark">Observaciones</label>
+                    <input type="text" id="observaciones" class="form-control" />
+                </div>
+            </div>
+
+            <div class="row g-3 align-items-end mb-5">
+                <div class="col-md-4">
+                    <label for="descripcion_prueba" class="form-label fw-semibold text-dark">Descripción de Prueba <span class="text-danger">*</span></label>
+                    <input type="text" id="descripcion_prueba" class="form-control" />
+                </div>
+                <div class="col-md-4">
+                    <label for="resultado" class="form-label fw-semibold text-dark">Resultado</label>
+                    <input type="text" id="resultado" class="form-control" />
+                </div>
+                <div class="col-md-2">
+                    <label for="obs_detalle" class="form-label fw-semibold text-dark">Observación</label>
+                    <input type="text" id="obs_detalle" class="form-control" />
+                </div>
+                <div class="col-md-2 text-center">
+                    <button type="button" class="btn btn-primary w-100" onclick="agregarDetalleDiagnostico(); return false;" data-bs-toggle="tooltip" data-bs-placement="top" title="Agregar prueba">
+                        <i class="bi bi-plus-circle me-2 fs-5"></i> Agregar
+                    </button>
+                </div>
+            </div>
+
+            <div class="mb-5">
+                <table class="table table-bordered table-hover align-middle text-center">
+                    <thead class="table-dark">
+                        <tr>
+                            <th>Descripción</th>
+                            <th>Resultado</th>
+                            <th>Observación</th>
+                            <th>Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="detalle_diagnostico_tb" class="table-group-divider text-dark">
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="row g-3">
+                <div class="col-md-6 d-grid">
+                    <button type="submit" class="btn btn-success btn-lg" onclick="guardarDiagnostico();">
+                        <i class="bi bi-save2 me-2 fs-5"></i> Guardar
+                    </button>
+                </div>
+                <div class="col-md-6 d-grid">
+                    <button type="button" class="btn btn-danger btn-lg" onclick="mostrarListarDiagnostico();">
+                        <i class="bi bi-x-circle me-2 fs-5"></i> Cancelar
+                    </button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+    var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+    var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+      return new bootstrap.Tooltip(tooltipTriggerEl)
+    })
+</script>

--- a/paginas/movimientos/servicios/diagnostico/imprimir.php
+++ b/paginas/movimientos/servicios/diagnostico/imprimir.php
@@ -1,0 +1,91 @@
+<?php
+require_once '../../../../conexion/db.php';
+
+$conexion = new DB();
+$id_diagnostico = $_GET['id'] ?? 0;
+
+if (!$id_diagnostico) {
+    die("ID de diagnóstico no especificado");
+}
+
+$queryCabecera = $conexion->conectar()->prepare("SELECT dc.id_diagnostico, dc.fecha_diagnostico, dc.costo_estimado, dc.estado_diagnostico, dc.observaciones, rc.id_recepcion_cabecera, CONCAT(c.nombre, ' ', c.apellido) AS cliente_nombre, e.marca, e.modelo FROM diagnostico_cabecera dc JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente JOIN equipo e ON e.id_equipo = rc.id_equipo WHERE dc.id_diagnostico = :id");
+$queryCabecera->execute(['id' => $id_diagnostico]);
+$cabecera = $queryCabecera->fetch(PDO::FETCH_OBJ);
+
+if (!$cabecera) {
+    die("Diagnóstico no encontrado");
+}
+
+$queryDetalle = $conexion->conectar()->prepare("SELECT descripcion_prueba, resultado, observaciones FROM diagnostico_detalle WHERE id_diagnostico = :id");
+$queryDetalle->execute(['id' => $id_diagnostico]);
+$detalles = $queryDetalle->fetchAll(PDO::FETCH_OBJ);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Etiqueta Diagnóstico</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      font-size: 10px;
+      margin: 10px;
+    }
+    .label {
+      width: 280px;
+      border: 1px solid #000;
+      padding: 8px;
+    }
+    .title {
+      text-align: center;
+      font-weight: bold;
+      font-size: 12px;
+      margin-bottom: 6px;
+    }
+    .section {
+      margin-bottom: 6px;
+    }
+    .section p {
+      margin: 2px 0;
+    }
+    .problem {
+      font-size: 9px;
+      border-top: 1px dashed #000;
+      margin-top: 4px;
+      padding-top: 4px;
+    }
+    .bold {
+      font-weight: bold;
+    }
+  </style>
+</head>
+<body onload="window.print()">
+  <div class="label">
+    <div class="title">DIAGNÓSTICO TÉCNICO</div>
+    <div class="section">
+      <p><span class="bold">ID:</span> #<?php echo $cabecera->id_diagnostico ?></p>
+      <p><span class="bold">Fecha:</span> <?php echo $cabecera->fecha_diagnostico ?></p>
+      <p><span class="bold">Estado:</span> <?php echo strtoupper($cabecera->estado_diagnostico) ?></p>
+      <p><span class="bold">Recepción:</span> <?php echo $cabecera->id_recepcion_cabecera ?></p>
+    </div>
+    <div class="section">
+      <p><span class="bold">Cliente:</span> <?php echo htmlspecialchars($cabecera->cliente_nombre) ?></p>
+      <p><span class="bold">Equipo:</span> <?php echo htmlspecialchars($cabecera->marca . ' ' . $cabecera->modelo) ?></p>
+      <p><span class="bold">Costo:</span> <?php echo $cabecera->costo_estimado ?></p>
+      <p><span class="bold">Obs:</span> <?php echo htmlspecialchars($cabecera->observaciones) ?></p>
+    </div>
+    <div class="section problem">
+      <span class="bold">Pruebas:</span><br>
+      <?php if (count($detalles) === 0): ?>
+        <em>Sin descripción</em>
+      <?php else: ?>
+        <ul style="padding-left: 12px; margin: 0;">
+          <?php foreach ($detalles as $d): ?>
+            <li><?php echo htmlspecialchars($d->descripcion_prueba . ' - ' . $d->resultado) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      <?php endif; ?>
+    </div>
+  </div>
+</body>
+</html>

--- a/paginas/movimientos/servicios/diagnostico/listar.php
+++ b/paginas/movimientos/servicios/diagnostico/listar.php
@@ -1,0 +1,27 @@
+<div class="row align-items-center mb-3">
+    <div class="col-md-8">
+        <h3 class="text-primary fw-bold">📋 Lista de Diagnósticos</h3>
+    </div>
+    <div class="col-md-4 text-end">
+        <button class="btn btn-success" onclick="mostrarAgregarDiagnostico(); return false;">
+            <i class="bi bi-plus-circle me-1"></i> Agregar Nuevo Diagnóstico
+        </button>
+    </div>
+</div>
+
+<div class="table-responsive">
+    <table class="table table-sm table-bordered table-hover align-middle">
+        <thead class="table-dark text-center">
+            <tr>
+                <th>#</th>
+                <th>Recepción</th>
+                <th>Fecha</th>
+                <th>Costo Estimado</th>
+                <th>Estado</th>
+                <th>Operaciones</th>
+            </tr>
+        </thead>
+        <tbody id="diagnostico_tb" class="text-center">
+        </tbody>
+    </table>
+</div>

--- a/vistas/diagnostico.js
+++ b/vistas/diagnostico.js
@@ -1,0 +1,154 @@
+function mostrarListarDiagnostico() {
+    let contenido = dameContenido("paginas/movimientos/servicios/diagnostico/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaDiagnostico();
+}
+
+function mostrarAgregarDiagnostico() {
+    let contenido = dameContenido("paginas/movimientos/servicios/diagnostico/agregar.php");
+    $("#contenido-principal").html(contenido);
+    dameFechaActual("fecha");
+    cargarListaRecepcion("#recepcion_lst");
+}
+
+function cargarListaRecepcion(componente) {
+    let datos = ejecutarAjax("controladores/diagnostico.php", "leer_recepcion=1");
+    let option = "";
+    if (datos === "0") {
+        option = "<option value='0'>Selecciona una opción</option>";
+    } else {
+        option = "<option value='0'>Selecciona una opción</option>";
+        let json_datos = JSON.parse(datos);
+        json_datos.map(function (item) {
+            option += `<option value="${item.id_recepcion_cabecera}">${item.id_recepcion_cabecera} - ${item.cliente}</option>`;
+        });
+    }
+    $(componente).html(option);
+}
+
+function agregarDetalleDiagnostico() {
+    if ($("#descripcion_prueba").val().trim().length === 0) {
+        mensaje_dialogo_info_ERROR("Debes de ingresar una descripción", "ATENCION");
+        return;
+    }
+    if ($("#resultado").val().trim().length === 0) {
+        $("#resultado").val("SIN RESULTADO");
+    }
+    if ($("#obs_detalle").val().trim().length === 0) {
+        $("#obs_detalle").val("SIN OBS");
+    }
+
+    $("#detalle_diagnostico_tb").append(`
+        <tr>
+            <td>${$("#descripcion_prueba").val()}</td>
+            <td>${$("#resultado").val()}</td>
+            <td>${$("#obs_detalle").val()}</td>
+            <td><button class="btn btn-danger remover-detalle">Remover</button></td>
+        </tr>
+    `);
+
+    $("#descripcion_prueba").val("");
+    $("#resultado").val("");
+    $("#obs_detalle").val("");
+}
+
+$(document).on("click", ".remover-detalle", function (evt) {
+    var tr = $(this).closest("tr");
+    Swal.fire({
+        title: "Atencion",
+        text: "Desea remover el registro?",
+        icon: "question",
+        showCancelButton: true,
+        confirmButtonColor: "#3085d6",
+        cancelButtonColor: "#d33",
+        cancelButtonText: "No",
+        confirmButtonText: "Si",
+    }).then((result) => {
+        if (result.isConfirmed) {
+            $(tr).remove();
+        }
+    });
+});
+
+function guardarDiagnostico() {
+    if ($("#detalle_diagnostico_tb").html().trim().length === 0) {
+        mensaje_dialogo_info("Debes de agregar datos en la tabla", "Atención");
+        return;
+    }
+    if ($("#recepcion_lst").val() === "0") {
+        mensaje_dialogo_info_ERROR("Debes seleccionar una recepción", "ATENCION");
+        return;
+    }
+    let data = {
+        'id_recepcion_cabecera': $("#recepcion_lst").val(),
+        'fecha_diagnostico': $("#fecha").val(),
+        'id_tecnico': null,
+        'costo_estimado': $("#costo_estimado").val(),
+        'estado_diagnostico': "Pendiente",
+        'observaciones': $("#observaciones").val()
+    };
+    let response = ejecutarAjax("controladores/diagnostico.php", "guardar=" + JSON.stringify(data));
+    let id = ejecutarAjax("controladores/diagnostico.php", "dameUltimoID=1");
+    $("#detalle_diagnostico_tb tr").each(function () {
+        let detalle = {
+            'id_diagnostico': id,
+            'descripcion_prueba': $(this).find("td:eq(0)").text(),
+            'resultado': $(this).find("td:eq(1)").text(),
+            'observaciones': $(this).find("td:eq(2)").text()
+        };
+        ejecutarAjax("controladores/diagnostico.php", "guardar_detalle=" + JSON.stringify(detalle));
+    });
+    mensaje_dialogo_info("Guardado Correctamente", "Exitoso");
+    mostrarListarDiagnostico();
+}
+
+function cargarTablaDiagnostico() {
+    let datos = ejecutarAjax("controladores/diagnostico.php", "leer_diagnostico=1");
+    let fila = "";
+    if (datos === "0") {
+        fila = "NO HAY REGISTROS";
+    } else {
+        let json_datos = JSON.parse(datos);
+        json_datos.map(function (item) {
+            fila += `<tr>`;
+            fila += `<td>${item.id_diagnostico}</td>`;
+            fila += `<td>${item.id_recepcion_cabecera}</td>`;
+            fila += `<td>${item.fecha_diagnostico}</td>`;
+            fila += `<td>${item.costo_estimado}</td>`;
+            fila += `<td>${item.estado_diagnostico}</td>`;
+            fila += `<td><button class="btn btn-danger anular-diagnostico">Anular</button> <button class="btn btn-primary imprimir-diagnostico">Impresion</button></td>`;
+            fila += `</tr>`;
+        });
+    }
+    $("#diagnostico_tb").html(fila);
+}
+
+$(document).on("click", ".anular-diagnostico", function (evt) {
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    let estado = $(this).closest("tr").find("td:eq(4)").text();
+    if (estado.trim() === 'ANULADO') {
+        mensaje_dialogo_info_ERROR("No puedes anular este registro", "ATENCION");
+        return;
+    }
+    Swal.fire({
+        title: 'Estas seguro?',
+        text: "Desea anular esta registro?",
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#d33',
+        cancelButtonText: 'No',
+        confirmButtonText: 'Si'
+    }).then((result) => {
+        if (result.isConfirmed) {
+            ejecutarAjax("controladores/diagnostico.php", "anular=" + id);
+            mensaje_dialogo_info("Anulado correctamente", "ANULADO");
+            cargarTablaDiagnostico();
+        }
+    });
+});
+
+$(document).on("click", ".imprimir-diagnostico", function (evt) {
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    window.open("paginas/movimientos/servicios/diagnostico/imprimir.php?id=" + id);
+});


### PR DESCRIPTION
## Summary
- Add diagnostico module with full CRUD flow (controller, views and scripts)
- Extend navigation and scripts to include diagnostico service
- Define diagnostico tables in SQL schema

## Testing
- `node --check vistas/diagnostico.js && php -l controladores/diagnostico.php && php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_688ff0e116f883338aa780bef21ec810