### PR TITLE
Add service budget module

### DIFF
--- a/controladores/presupuesto_servicio.php
+++ b/controladores/presupuesto_servicio.php
@@ -1,0 +1,55 @@
+<?php
+require_once '../conexion/db.php';
+
+if(isset($_POST['leer'])){
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT id_presupuesto_servicio, id_diagnostico, fecha_presupuesto, validez_dias, estado, observaciones FROM presupuesto_servicio_cabecera ORDER BY id_presupuesto_servicio DESC");
+    $query->execute();
+    if($query->rowCount()){
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    }else{
+        echo '0';
+    }
+}
+
+if(isset($_POST['guardar'])){
+    $json = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO presupuesto_servicio_cabecera(id_diagnostico, fecha_presupuesto, validez_dias, estado, observaciones) VALUES(:id_diagnostico, :fecha_presupuesto, :validez_dias, :estado, :observaciones)");
+    $query->execute($json);
+    $upd = $conexion->conectar()->prepare("UPDATE diagnostico_cabecera SET estado_diagnostico='UTILIZADO' WHERE id_diagnostico=:id");
+    $upd->execute(['id'=>$json['id_diagnostico']]);
+}
+
+if(isset($_POST['dameUltimoId'])){
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT MAX(id_presupuesto_servicio) AS id FROM presupuesto_servicio_cabecera");
+    $query->execute();
+    $r = $query->fetch(PDO::FETCH_OBJ);
+    echo $r ? $r->id : '0';
+}
+
+if(isset($_POST['guardar_detalle'])){
+    $json = json_decode($_POST['guardar_detalle'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO presupuesto_servicio_detalle(id_presupuesto_servicio, concepto, cantidad, precio_unitario) VALUES(:id_presupuesto_servicio, :concepto, :cantidad, :precio_unitario)");
+    $query->execute($json);
+}
+
+if(isset($_POST['leer_detalle'])){
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT id_detalle_presu, concepto, cantidad, precio_unitario, subtotal FROM presupuesto_servicio_detalle WHERE id_presupuesto_servicio=:id");
+    $query->execute(['id'=>$_POST['leer_detalle']]);
+    if($query->rowCount()){
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    }else{
+        echo '0';
+    }
+}
+
+if(isset($_POST['anular'])){
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("UPDATE presupuesto_servicio_cabecera SET estado='ANULADO' WHERE id_presupuesto_servicio=:id");
+    $query->execute(['id'=>$_POST['anular']]);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -411,6 +411,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                             <p>Diagnóstico</p>
                                         </a>
                                     </li>
+                                    <li class="nav-item">
+                                        <a href="#" onclick="mostrarListarPresupuestoServicio();" class="nav-link">
+                                            <i class="nav-icon bi bi-circle"></i>
+                                            <p>Presupuesto Servicio</p>
+                                        </a>
+                                    </li>
                                 </ul>
                             </li>
 
@@ -724,6 +730,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/tecnico.js"></script>
         <script src="vistas/recepcion.js"></script>
         <script src="vistas/diagnostico.js"></script>
+        <script src="vistas/presupuesto_servicio.js"></script>
         <script src="vistas/pedido_proveedor.js"></script>
         <script src="vistas/presupuesto.js"></script>
         <script src="vistas/orden_compra.js"></script>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -747,6 +747,36 @@ ALTER TABLE `diagnostico_cabecera`
 ALTER TABLE `diagnostico_detalle`
   MODIFY `id_diagnostico_detalle` int(11) NOT NULL AUTO_INCREMENT;
 
+-- --------------------------------------------------------
+-- Estructura de tabla para la tabla `presupuesto_servicio_cabecera`
+-- --------------------------------------------------------
+CREATE TABLE `presupuesto_servicio_cabecera` (
+  `id_presupuesto_servicio` int(11) NOT NULL AUTO_INCREMENT,
+  `id_diagnostico` int(11) NOT NULL,
+  `fecha_presupuesto` date NOT NULL DEFAULT curdate(),
+  `validez_dias` int(11) NOT NULL DEFAULT 7,
+  `estado` varchar(20) NOT NULL DEFAULT 'Enviado',
+  `observaciones` text DEFAULT NULL,
+  PRIMARY KEY (`id_presupuesto_servicio`),
+  KEY `fk_presu_diag` (`id_diagnostico`),
+  CONSTRAINT `fk_presu_diag` FOREIGN KEY (`id_diagnostico`) REFERENCES `diagnostico_cabecera` (`id_diagnostico`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+-- Estructura de tabla para la tabla `presupuesto_servicio_detalle`
+-- --------------------------------------------------------
+CREATE TABLE `presupuesto_servicio_detalle` (
+  `id_detalle_presu` int(11) NOT NULL AUTO_INCREMENT,
+  `id_presupuesto_servicio` int(11) NOT NULL,
+  `concepto` varchar(100) NOT NULL,
+  `cantidad` int(11) NOT NULL DEFAULT 1,
+  `precio_unitario` int(11) NOT NULL,
+  `subtotal` int(11) GENERATED ALWAYS AS (`cantidad` * `precio_unitario`) STORED,
+  PRIMARY KEY (`id_detalle_presu`),
+  KEY `fk_detalle_presu_cab` (`id_presupuesto_servicio`),
+  CONSTRAINT `fk_detalle_presu_cab` FOREIGN KEY (`id_presupuesto_servicio`) REFERENCES `presupuesto_servicio_cabecera` (`id_presupuesto_servicio`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
 --
 -- AUTO_INCREMENT de la tabla `servicio`
 --

--- a/paginas/movimientos/servicios/presupuesto/agregar.php
+++ b/paginas/movimientos/servicios/presupuesto/agregar.php
@@ -1,0 +1,85 @@
+<div class="container mt-5">
+  <div class="card shadow-lg rounded-4 p-5 bg-white">
+    <h3 class="mb-4 text-primary fw-bold">NUEVO PRESUPUESTO DE SERVICIO</h3>
+    <hr>
+    <div class="row g-4 mb-4">
+      <div class="col-md-4">
+        <label for="fecha" class="form-label fw-semibold text-dark">Fecha <span class="text-danger">*</span></label>
+        <input type="date" id="fecha" class="form-control" required />
+      </div>
+      <div class="col-md-4">
+        <label for="diagnostico_lst" class="form-label fw-semibold text-dark">Diagnóstico <span class="text-danger">*</span></label>
+        <select id="diagnostico_lst" class="form-select" required>
+          <option value="0">-- Seleccione un diagnóstico --</option>
+        </select>
+      </div>
+      <div class="col-md-4">
+        <label for="validez" class="form-label fw-semibold text-dark">Validez (días)</label>
+        <input type="number" id="validez" class="form-control" value="7" />
+      </div>
+    </div>
+
+    <div class="row g-4 mb-4">
+      <div class="col-md-12">
+        <label for="observaciones" class="form-label fw-semibold text-dark">Observaciones</label>
+        <input type="text" id="observaciones" class="form-control" />
+      </div>
+    </div>
+
+    <hr class="mb-4">
+
+    <div class="row g-3 align-items-end mb-5">
+      <div class="col-md-6">
+        <label for="concepto" class="form-label fw-semibold text-dark">Concepto <span class="text-danger">*</span></label>
+        <input type="text" id="concepto" class="form-control" />
+      </div>
+      <div class="col-md-2">
+        <label for="cantidad" class="form-label fw-semibold text-dark">Cantidad <span class="text-danger">*</span></label>
+        <input type="number" id="cantidad" class="form-control" value="1" min="1" />
+      </div>
+      <div class="col-md-2">
+        <label for="precio_unitario" class="form-label fw-semibold text-dark">Precio <span class="text-danger">*</span></label>
+        <input type="number" id="precio_unitario" class="form-control" value="0" min="0" />
+      </div>
+      <div class="col-md-2 text-center">
+        <button type="button" class="btn btn-primary w-100" onclick="agregarDetallePresupuestoServicio(); return false;">
+          <i class="bi bi-plus-circle me-2 fs-5"></i> Agregar
+        </button>
+      </div>
+    </div>
+
+    <div class="mb-5">
+      <table class="table table-bordered table-hover align-middle text-center">
+        <thead class="table-dark">
+          <tr>
+            <th>Concepto</th>
+            <th>Cantidad</th>
+            <th>Precio</th>
+            <th>Subtotal</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody id="detalle_presupuesto_servicio_tb" class="table-group-divider text-dark"></tbody>
+      </table>
+    </div>
+
+    <div class="row mb-4">
+      <div class="col-md-12 text-end">
+        <h5>Total: <span id="total_presupuesto_servicio">0</span></h5>
+      </div>
+    </div>
+
+    <div class="row g-3">
+      <div class="col-md-6 d-grid">
+        <button type="button" class="btn btn-success btn-lg" onclick="guardarPresupuestoServicio();">
+          <i class="bi bi-save2 me-2 fs-5"></i> Confirmar
+        </button>
+      </div>
+      <div class="col-md-6 d-grid">
+        <button type="button" class="btn btn-danger btn-lg" onclick="mostrarListarPresupuestoServicio();">
+          <i class="bi bi-x-circle me-2 fs-5"></i> Cancelar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/paginas/movimientos/servicios/presupuesto/listar.php
+++ b/paginas/movimientos/servicios/presupuesto/listar.php
@@ -1,0 +1,26 @@
+<div class="row align-items-center mb-3">
+  <div class="col-md-8">
+    <h3 class="text-primary fw-bold">📋 Lista de Presupuestos de Servicio</h3>
+  </div>
+  <div class="col-md-4 text-end">
+    <button class="btn btn-success" onclick="mostrarAgregarPresupuestoServicio(); return false;">
+      <i class="bi bi-plus-circle me-1"></i> Agregar Nuevo Presupuesto
+    </button>
+  </div>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-sm table-bordered table-hover align-middle">
+    <thead class="table-dark text-center">
+      <tr>
+        <th>#</th>
+        <th>Diagnóstico</th>
+        <th>Fecha</th>
+        <th>Estado</th>
+        <th>Observaciones</th>
+        <th>Operaciones</th>
+      </tr>
+    </thead>
+    <tbody id="presupuesto_servicio_tb" class="text-center"></tbody>
+  </table>
+</div>

--- a/vistas/presupuesto_servicio.js
+++ b/vistas/presupuesto_servicio.js
@@ -1,0 +1,125 @@
+function mostrarListarPresupuestoServicio(){
+    let contenido = dameContenido("paginas/movimientos/servicios/presupuesto/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaPresupuestoServicio();
+}
+
+function mostrarAgregarPresupuestoServicio(){
+    let contenido = dameContenido("paginas/movimientos/servicios/presupuesto/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaDiagnostico("#diagnostico_lst");
+    dameFechaActual("fecha");
+}
+
+function cargarTablaPresupuestoServicio(){
+    let data = ejecutarAjax("controladores/presupuesto_servicio.php","leer=1");
+    $("#presupuesto_servicio_tb").html("");
+    if(data === "0"){
+        $("#presupuesto_servicio_tb").html("<tr><td colspan='6'>NO HAY REGISTRO</td></tr>");
+    }else{
+        let json_data = JSON.parse(data);
+        json_data.map(function(item){
+            $("#presupuesto_servicio_tb").append(`
+                <tr>
+                    <td>${item.id_presupuesto_servicio}</td>
+                    <td>${item.id_diagnostico}</td>
+                    <td>${item.fecha_presupuesto}</td>
+                    <td>${item.estado}</td>
+                    <td>${item.observaciones || ''}</td>
+                    <td><button class='btn btn-danger anular-presupuesto-servicio'>Anular</button></td>
+                </tr>
+            `);
+        });
+    }
+}
+
+$(document).on("click",".anular-presupuesto-servicio",function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    if(confirm("¿Anular presupuesto?")){
+        ejecutarAjax("controladores/presupuesto_servicio.php","anular="+id);
+        cargarTablaPresupuestoServicio();
+    }
+});
+
+function cargarListaDiagnostico(componente){
+    let data = ejecutarAjax("controladores/diagnostico.php","leer_diagnostico=1");
+    if(data === "0"){
+        $(componente).html("<option value='0'>Sin diagnósticos</option>");
+    }else{
+        let json_data = JSON.parse(data);
+        $(componente).html("<option value='0'>-- Seleccione un diagnóstico --</option>");
+        json_data.map(function(item){
+            $(componente).append(`<option value="${item.id_diagnostico}">${item.id_diagnostico}</option>`);
+        });
+    }
+}
+
+function agregarDetallePresupuestoServicio(){
+    if($("#concepto").val().trim().length === 0){
+        alert("Ingrese concepto");
+        return;
+    }
+    let cantidad = parseInt($("#cantidad").val()) || 0;
+    let precio = parseInt($("#precio_unitario").val()) || 0;
+    if(cantidad <= 0 || precio <= 0){
+        alert("Cantidad y precio deben ser mayores a cero");
+        return;
+    }
+    let subtotal = cantidad * precio;
+    $("#detalle_presupuesto_servicio_tb").append(`
+        <tr data-subtotal="${subtotal}">
+            <td>${$("#concepto").val()}</td>
+            <td>${cantidad}</td>
+            <td>${formatearNumero(precio)}</td>
+            <td>${formatearNumero(subtotal)}</td>
+            <td><button class='btn btn-danger remover-item'>Remover</button></td>
+        </tr>
+    `);
+    calcularTotalPresupuestoServicio();
+    $("#concepto").val('');
+    $("#cantidad").val(1);
+    $("#precio_unitario").val(0);
+}
+
+$(document).on("click",".remover-item",function(){
+    $(this).closest("tr").remove();
+    calcularTotalPresupuestoServicio();
+});
+
+function calcularTotalPresupuestoServicio(){
+    let total = 0;
+    $("#detalle_presupuesto_servicio_tb tr").each(function(){
+        total += parseInt($(this).data("subtotal")) || 0;
+    });
+    $("#total_presupuesto_servicio").text(formatearNumero(total));
+}
+
+function guardarPresupuestoServicio(){
+    if($("#diagnostico_lst").val() === "0"){
+        alert("Seleccione un diagnóstico");
+        return;
+    }
+    if($("#detalle_presupuesto_servicio_tb tr").length === 0){
+        alert("Agregue detalle");
+        return;
+    }
+    let cab = {
+        id_diagnostico: $("#diagnostico_lst").val(),
+        fecha_presupuesto: $("#fecha").val(),
+        validez_dias: $("#validez").val(),
+        estado: 'Enviado',
+        observaciones: $("#observaciones").val()
+    };
+    ejecutarAjax("controladores/presupuesto_servicio.php","guardar="+JSON.stringify(cab));
+    let id = ejecutarAjax("controladores/presupuesto_servicio.php","dameUltimoId=1");
+    $("#detalle_presupuesto_servicio_tb tr").each(function(){
+        let det = {
+            id_presupuesto_servicio: id,
+            concepto: $(this).find("td:eq(0)").text(),
+            cantidad: parseInt($(this).find("td:eq(1)").text()),
+            precio_unitario: quitarFormatoNumero($(this).find("td:eq(2)").text())
+        };
+        ejecutarAjax("controladores/presupuesto_servicio.php","guardar_detalle="+JSON.stringify(det));
+    });
+    mostrarListarPresupuestoServicio();
+}


### PR DESCRIPTION
## Summary
- add Presupuesto Servicio menu and script hookup
- implement CRUD controller and pages for service budgets
- update SQL schema with presupuesto_servicio tables and mark diagnosticos as UTILIZADO on use

## Testing
- `php -l index.php`
- `php -l controladores/presupuesto_servicio.php`
- `php -l paginas/movimientos/servicios/presupuesto/agregar.php`
- `php -l paginas/movimientos/servicios/presupuesto/listar.php`


------
https://chatgpt.com/codex/tasks/task_e_688ff3d76be48333898680a7a938c978