### PR TITLE
Fix service saving by returning ID and encoding data

### DIFF
--- a/vistas/servicio.js
+++ b/vistas/servicio.js
@@ -124,8 +124,7 @@ function guardarServicio(){
         observaciones: $("#observaciones").val()
     };
     console.log(cab);
-    ejecutarAjax("controladores/servicio.php","guardar="+JSON.stringify(cab));
-    let id = ejecutarAjax("controladores/servicio.php","dameUltimoId=1");
+    let id = ejecutarAjax("controladores/servicio.php","guardar="+encodeURIComponent(JSON.stringify(cab)));
     $("#detalle_servicio_tb tr").each(function(){
         let det = {
             id_servicio: id,
@@ -134,7 +133,7 @@ function guardarServicio(){
             observaciones: $(this).find("td:eq(2)").text()
         };
         console.log(det);
-        ejecutarAjax("controladores/servicio.php","guardar_detalle="+JSON.stringify(det));
+        ejecutarAjax("controladores/servicio.php","guardar_detalle="+encodeURIComponent(JSON.stringify(det)));
     });
     mensaje_dialogo_info("Servicio registrado correctamente","REGISTRADO");
     mostrarListarServicio();


### PR DESCRIPTION
## Summary
- Return new service ID after saving header and update related budget
- Encode payloads and reuse returned ID when saving service details

## Testing
- `php -l controladores/servicio.php`
- `node --check vistas/servicio.js && echo 'JS OK'`


------
https://chatgpt.com/codex/tasks/task_e_689017c6f8648333893c096ccb9db3c1