### PR TITLE
Agregar módulo de entrega de servicios

### DIFF
--- a/controladores/servicio_entrega.php
+++ b/controladores/servicio_entrega.php
@@ -1,0 +1,38 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['leer_servicio'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT sc.id_servicio, CONCAT(c.nombre,' ',c.apellido) AS cliente FROM servicio_cabecera sc JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente LEFT JOIN servicio_entrega se ON se.id_servicio = sc.id_servicio WHERE se.id_servicio IS NULL");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['guardar'])) {
+    $json_datos = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO servicio_entrega (id_servicio, fecha_entrega, firmado_por) VALUES (:id_servicio, :fecha_entrega, :firmado_por)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT se.id_entrega, se.fecha_entrega, se.firmado_por, sc.id_servicio, CONCAT(c.nombre,' ',c.apellido) AS cliente FROM servicio_entrega se JOIN servicio_cabecera sc ON se.id_servicio = sc.id_servicio JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente ORDER BY se.id_entrega DESC");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['anular'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("DELETE FROM servicio_entrega WHERE id_entrega = :id");
+    $query->execute(['id' => $_POST['anular']]);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -423,6 +423,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                             <p>Servicio</p>
                                         </a>
                                     </li>
+                                    <li class="nav-item">
+                                        <a href="#" onclick="mostrarListarEntrega();" class="nav-link">
+                                            <i class="nav-icon bi bi-circle"></i>
+                                            <p>Entrega</p>
+                                        </a>
+                                    </li>
                                 </ul>
                             </li>
 
@@ -738,6 +744,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/diagnostico.js"></script>
         <script src="vistas/presupuesto_servicio.js"></script>
         <script src="vistas/servicio.js"></script>
+        <script src="vistas/entrega.js"></script>
         <script src="vistas/pedido_proveedor.js"></script>
         <script src="vistas/presupuesto.js"></script>
         <script src="vistas/orden_compra.js"></script>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -811,6 +811,21 @@ CREATE TABLE servicio_detalle (
       ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- --------------------------------------------------------
+-- Estructura de tabla para la tabla `servicio_entrega`
+-- --------------------------------------------------------
+CREATE TABLE servicio_entrega (
+  id_entrega INT AUTO_INCREMENT PRIMARY KEY,
+  id_servicio INT NOT NULL,
+  fecha_entrega DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  firmado_por VARCHAR(100) NULL,
+  CONSTRAINT fk_ent_srv
+    FOREIGN KEY (id_servicio)
+    REFERENCES servicio_cabecera(id_servicio)
+      ON DELETE RESTRICT
+      ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 --
 -- AUTO_INCREMENT de la tabla `servicio`
 --

--- a/paginas/movimientos/servicios/entrega/agregar.php
+++ b/paginas/movimientos/servicios/entrega/agregar.php
@@ -1,0 +1,34 @@
+<div class="container mt-5">
+  <div class="card shadow-lg rounded-4 p-5 bg-white">
+    <h3 class="mb-4 text-primary fw-bold">NUEVA ENTREGA</h3>
+    <hr>
+    <div class="row g-4 mb-4">
+      <div class="col-md-6">
+        <label for="servicio_lst" class="form-label fw-semibold text-dark">Servicio <span class="text-danger">*</span></label>
+        <select id="servicio_lst" class="form-select" required>
+          <option value="0">-- Seleccione un servicio --</option>
+        </select>
+      </div>
+      <div class="col-md-6">
+        <label for="fecha_entrega" class="form-label fw-semibold text-dark">Fecha Entrega <span class="text-danger">*</span></label>
+        <input type="date" id="fecha_entrega" class="form-control" required />
+      </div>
+      <div class="col-md-12">
+        <label for="firmado_por" class="form-label fw-semibold text-dark">Firmado por</label>
+        <input type="text" id="firmado_por" class="form-control" />
+      </div>
+    </div>
+    <div class="row g-3">
+      <div class="col-md-6 d-grid">
+        <button type="button" class="btn btn-success btn-lg" onclick="guardarEntrega();">
+          <i class="bi bi-save2 me-2 fs-5"></i> Confirmar
+        </button>
+      </div>
+      <div class="col-md-6 d-grid">
+        <button type="button" class="btn btn-danger btn-lg" onclick="mostrarListarEntrega();">
+          <i class="bi bi-x-circle me-2 fs-5"></i> Cancelar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/paginas/movimientos/servicios/entrega/imprimir.php
+++ b/paginas/movimientos/servicios/entrega/imprimir.php
@@ -1,0 +1,33 @@
+<?php
+require_once '../../../../conexion/db.php';
+$conexion = new DB();
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if ($id <= 0) {
+    die('ID no valido');
+}
+$query = $conexion->conectar()->prepare("SELECT se.id_entrega, se.fecha_entrega, se.firmado_por, sc.id_servicio, CONCAT(c.nombre,' ',c.apellido) AS cliente FROM servicio_entrega se JOIN servicio_cabecera sc ON se.id_servicio = sc.id_servicio JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente WHERE se.id_entrega = :id");
+$query->execute(['id' => $id]);
+$cab = $query->fetch(PDO::FETCH_OBJ);
+if (!$cab) {
+    die('Entrega no encontrada');
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Entrega #<?= htmlspecialchars($cab->id_entrega) ?></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body onload="window.print()">
+  <div class="container mt-4">
+    <h3 class="text-center mb-4">ENTREGA N° <?= htmlspecialchars($cab->id_entrega) ?></h3>
+    <p><strong>Servicio:</strong> <?= htmlspecialchars($cab->id_servicio) ?></p>
+    <p><strong>Cliente:</strong> <?= htmlspecialchars($cab->cliente) ?></p>
+    <p><strong>Fecha Entrega:</strong> <?= htmlspecialchars($cab->fecha_entrega) ?></p>
+    <?php if(!empty($cab->firmado_por)): ?>
+    <p><strong>Firmado por:</strong> <?= htmlspecialchars($cab->firmado_por) ?></p>
+    <?php endif; ?>
+  </div>
+</body>
+</html>

--- a/paginas/movimientos/servicios/entrega/listar.php
+++ b/paginas/movimientos/servicios/entrega/listar.php
@@ -1,0 +1,24 @@
+<div class="row mb-3">
+  <div class="col-md-8">
+    <h3 class="text-primary fw-bold">📦 Lista de Entregas</h3>
+  </div>
+  <div class="col-md-4 text-end">
+    <button class="btn btn-success" onclick="mostrarAgregarEntrega(); return false;">
+      <i class="bi bi-plus-circle me-1"></i> Agregar Entrega
+    </button>
+  </div>
+</div>
+<div class="table-responsive">
+  <table class="table table-sm table-bordered table-hover align-middle">
+    <thead class="table-dark text-center">
+      <tr>
+        <th>#</th>
+        <th>Servicio</th>
+        <th>Fecha Entrega</th>
+        <th>Firmado Por</th>
+        <th>Operaciones</th>
+      </tr>
+    </thead>
+    <tbody id="entrega_tb" class="text-center"></tbody>
+  </table>
+</div>

--- a/vistas/entrega.js
+++ b/vistas/entrega.js
@@ -1,0 +1,87 @@
+function mostrarListarEntrega() {
+    let contenido = dameContenido("paginas/movimientos/servicios/entrega/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaEntrega();
+}
+
+function mostrarAgregarEntrega() {
+    let contenido = dameContenido("paginas/movimientos/servicios/entrega/agregar.php");
+    $("#contenido-principal").html(contenido);
+    dameFechaActual("fecha_entrega");
+    cargarListaServicios("#servicio_lst");
+}
+
+function cargarListaServicios(componente) {
+    let datos = ejecutarAjax("controladores/servicio_entrega.php", "leer_servicio=1");
+    let option = "";
+    if (datos === "0") {
+        option = "<option value='0'>Sin servicios</option>";
+    } else {
+        option = "<option value='0'>-- Seleccione un servicio --</option>";
+        let json_datos = JSON.parse(datos);
+        json_datos.map(function(item){
+            option += `<option value="${item.id_servicio}">${item.id_servicio} - ${item.cliente}</option>`;
+        });
+    }
+    $(componente).html(option);
+}
+
+function guardarEntrega() {
+    if($("#servicio_lst").val() === "0"){
+        mensaje_dialogo_info_ERROR("Debes seleccionar un servicio", "ATENCION");
+        return;
+    }
+    let data = {
+        id_servicio: $("#servicio_lst").val(),
+        fecha_entrega: $("#fecha_entrega").val(),
+        firmado_por: $("#firmado_por").val()
+    };
+    ejecutarAjax("controladores/servicio_entrega.php", "guardar=" + JSON.stringify(data));
+    mensaje_dialogo_info("Guardado Correctamente", "Exitoso");
+    mostrarListarEntrega();
+}
+
+function cargarTablaEntrega() {
+    let datos = ejecutarAjax("controladores/servicio_entrega.php", "leer=1");
+    let fila = "";
+    if (datos === "0") {
+        fila = "NO HAY REGISTROS";
+    } else {
+        let json_datos = JSON.parse(datos);
+        json_datos.map(function(item){
+            fila += `<tr>`;
+            fila += `<td>${item.id_entrega}</td>`;
+            fila += `<td>${item.id_servicio} - ${item.cliente}</td>`;
+            fila += `<td>${item.fecha_entrega}</td>`;
+            fila += `<td>${item.firmado_por || ''}</td>`;
+            fila += `<td><button class='btn btn-danger anular-entrega'>Anular</button> <button class='btn btn-primary imprimir-entrega'>Imprimir</button></td>`;
+            fila += `</tr>`;
+        });
+    }
+    $("#entrega_tb").html(fila);
+}
+
+$(document).on("click", ".anular-entrega", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    Swal.fire({
+        title: 'Estas seguro?',
+        text: "Desea anular esta registro?",
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#3085d6',
+        cancelButtonColor: '#d33',
+        cancelButtonText: 'No',
+        confirmButtonText: 'Si'
+    }).then((result) => {
+        if (result.isConfirmed) {
+            ejecutarAjax("controladores/servicio_entrega.php", "anular=" + id);
+            mensaje_dialogo_info("Anulado correctamente", "ANULADO");
+            cargarTablaEntrega();
+        }
+    });
+});
+
+$(document).on("click", ".imprimir-entrega", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    window.open("paginas/movimientos/servicios/entrega/imprimir.php?id=" + id);
+});


### PR DESCRIPTION
## Summary
- Añadida tabla `servicio_entrega` para registrar entregas de servicio
- Implementado CRUD y páginas de interfaz para gestionar entregas
- Incorporado módulo de entregas al menú principal y scripts de la aplicación

## Testing
- `php -l controladores/servicio_entrega.php`
- `php -l paginas/movimientos/servicios/entrega/agregar.php`
- `php -l paginas/movimientos/servicios/entrega/listar.php`
- `php -l paginas/movimientos/servicios/entrega/imprimir.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68902126decc8333bc999120818c2a9a