### PR TITLE
Add service warranty module

### DIFF
--- a/controladores/servicio_garantia.php
+++ b/controladores/servicio_garantia.php
@@ -1,0 +1,46 @@
+<?php
+require_once '../conexion/db.php';
+
+if(isset($_POST['leer'])){
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT sg.id_garantia, sg.id_servicio, sg.fecha_inicio, sg.duracion_dias, sg.estado, CONCAT(c.nombre,' ',c.apellido) as cliente FROM servicio_garantia sg JOIN servicio_cabecera sc ON sc.id_servicio = sg.id_servicio JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente ORDER BY sg.id_garantia DESC");
+    $query->execute();
+    if($query->rowCount()){
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    }else{
+        echo '0';
+    }
+}
+
+if(isset($_POST['leer_servicio'])){
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT sc.id_servicio, CONCAT(c.nombre,' ',c.apellido) as cliente FROM servicio_cabecera sc JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente LEFT JOIN servicio_garantia sg ON sg.id_servicio = sc.id_servicio WHERE sg.id_garantia IS NULL");
+    $query->execute();
+    if($query->rowCount()){
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    }else{
+        echo '0';
+    }
+}
+
+if(isset($_POST['guardar'])){
+    $json = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO servicio_garantia(id_servicio, fecha_inicio, duracion_dias, estado) VALUES(:id_servicio, :fecha_inicio, :duracion_dias, :estado)");
+    $query->execute($json);
+}
+
+if(isset($_POST['anular'])){
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("UPDATE servicio_garantia SET estado='ANULADO' WHERE id_garantia=:id");
+    $query->execute(['id'=>$_POST['anular']]);
+}
+
+if(isset($_POST['dameUltimoId'])){
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT MAX(id_garantia) AS id FROM servicio_garantia");
+    $query->execute();
+    $r = $query->fetch(PDO::FETCH_OBJ);
+    echo $r ? $r->id : '0';
+}
+?>

--- a/index.php
+++ b/index.php
@@ -418,6 +418,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                         </a>
                                     </li>
                                     <li class="nav-item">
+                                        <a href="#" onclick="mostrarListarGarantia();" class="nav-link">
+                                            <i class="nav-icon bi bi-circle"></i>
+                                            <p>Garantia</p>
+                                        </a>
+                                    </li>
+                                    <li class="nav-item">
                                         <a href="#" onclick="mostrarListarServicio();" class="nav-link">
                                             <i class="nav-icon bi bi-circle"></i>
                                             <p>Servicio</p>
@@ -738,6 +744,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/diagnostico.js"></script>
         <script src="vistas/presupuesto_servicio.js"></script>
         <script src="vistas/servicio.js"></script>
+        <script src="vistas/servicio_garantia.js"></script>
         <script src="vistas/pedido_proveedor.js"></script>
         <script src="vistas/presupuesto.js"></script>
         <script src="vistas/orden_compra.js"></script>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -811,6 +811,22 @@ CREATE TABLE servicio_detalle (
       ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- --------------------------------------------------------
+-- Estructura de tabla para la tabla `servicio_garantia`
+-- --------------------------------------------------------
+CREATE TABLE servicio_garantia (
+  id_garantia INT AUTO_INCREMENT PRIMARY KEY,
+  id_servicio INT NOT NULL,
+  fecha_inicio DATE NOT NULL DEFAULT CURRENT_DATE,
+  duracion_dias INT NOT NULL DEFAULT 30,
+  estado VARCHAR(20) NOT NULL DEFAULT 'Vigente',
+  CONSTRAINT fk_gar_srv
+    FOREIGN KEY (id_servicio)
+    REFERENCES servicio_cabecera(id_servicio)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 --
 -- AUTO_INCREMENT de la tabla `servicio`
 --

--- a/paginas/movimientos/servicios/garantia/agregar.php
+++ b/paginas/movimientos/servicios/garantia/agregar.php
@@ -1,0 +1,34 @@
+<div class="container mt-5">
+  <div class="card shadow-lg rounded-4 p-5 bg-white">
+    <h3 class="mb-4 text-primary fw-bold">NUEVA GARANTÍA DE SERVICIO</h3>
+    <hr>
+    <div class="row g-4 mb-4">
+      <div class="col-md-4">
+        <label for="servicio_lst" class="form-label fw-semibold text-dark">Servicio <span class="text-danger">*</span></label>
+        <select id="servicio_lst" class="form-select" required>
+          <option value="0">-- Seleccione un servicio --</option>
+        </select>
+      </div>
+      <div class="col-md-4">
+        <label for="fecha_inicio" class="form-label fw-semibold text-dark">Fecha Inicio <span class="text-danger">*</span></label>
+        <input type="date" id="fecha_inicio" class="form-control" required />
+      </div>
+      <div class="col-md-4">
+        <label for="duracion" class="form-label fw-semibold text-dark">Duración (días)</label>
+        <input type="number" id="duracion" class="form-control" value="30" />
+      </div>
+    </div>
+    <div class="row g-3">
+      <div class="col-md-6 d-grid">
+        <button type="button" class="btn btn-success btn-lg" onclick="guardarGarantia();">
+          <i class="bi bi-save2 me-2 fs-5"></i> Confirmar
+        </button>
+      </div>
+      <div class="col-md-6 d-grid">
+        <button type="button" class="btn btn-danger btn-lg" onclick="mostrarListarGarantia();">
+          <i class="bi bi-x-circle me-2 fs-5"></i> Cancelar
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/paginas/movimientos/servicios/garantia/imprimir.php
+++ b/paginas/movimientos/servicios/garantia/imprimir.php
@@ -1,0 +1,33 @@
+<?php
+require_once '../../../../conexion/db.php';
+$conexion = new DB();
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if($id <= 0){
+    die('ID no valido');
+}
+$query = $conexion->conectar()->prepare("SELECT sg.id_garantia, sg.fecha_inicio, sg.duracion_dias, sg.estado, sc.id_servicio, CONCAT(c.nombre,' ',c.apellido) as cliente FROM servicio_garantia sg JOIN servicio_cabecera sc ON sc.id_servicio = sg.id_servicio JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente WHERE sg.id_garantia=:id");
+$query->execute(['id'=>$id]);
+$cab = $query->fetch(PDO::FETCH_OBJ);
+if(!$cab){
+    die('Garantía no encontrada');
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Garantía Servicio #<?= htmlspecialchars($cab->id_garantia) ?></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body onload="window.print();">
+  <div class="container mt-4">
+    <h3 class="text-center">Garantía de Servicio</h3>
+    <hr>
+    <p><strong>N° Garantía:</strong> <?= $cab->id_garantia ?></p>
+    <p><strong>Servicio:</strong> <?= $cab->id_servicio ?> - <?= htmlspecialchars($cab->cliente) ?></p>
+    <p><strong>Fecha Inicio:</strong> <?= $cab->fecha_inicio ?></p>
+    <p><strong>Duración:</strong> <?= $cab->duracion_dias ?> días</p>
+    <p><strong>Estado:</strong> <?= $cab->estado ?></p>
+  </div>
+</body>
+</html>

--- a/paginas/movimientos/servicios/garantia/listar.php
+++ b/paginas/movimientos/servicios/garantia/listar.php
@@ -1,0 +1,26 @@
+<div class="row align-items-center mb-3">
+  <div class="col-md-8">
+    <h3 class="text-primary fw-bold">📋 Lista de Garantías de Servicio</h3>
+  </div>
+  <div class="col-md-4 text-end">
+    <button class="btn btn-success" onclick="mostrarAgregarGarantia(); return false;">
+      <i class="bi bi-plus-circle me-1"></i> Agregar Nueva Garantía
+    </button>
+  </div>
+</div>
+
+<div class="table-responsive">
+  <table class="table table-sm table-bordered table-hover align-middle">
+    <thead class="table-dark text-center">
+      <tr>
+        <th>#</th>
+        <th>Servicio</th>
+        <th>Fecha Inicio</th>
+        <th>Duración (días)</th>
+        <th>Estado</th>
+        <th>Operaciones</th>
+      </tr>
+    </thead>
+    <tbody id="garantia_tb" class="text-center"></tbody>
+  </table>
+</div>

--- a/vistas/servicio_garantia.js
+++ b/vistas/servicio_garantia.js
@@ -1,0 +1,95 @@
+function mostrarListarGarantia() {
+    let contenido = dameContenido("paginas/movimientos/servicios/garantia/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaGarantia();
+}
+
+function mostrarAgregarGarantia() {
+    let contenido = dameContenido("paginas/movimientos/servicios/garantia/agregar.php");
+    $("#contenido-principal").html(contenido);
+    cargarListaServicio("#servicio_lst");
+    dameFechaActual("fecha_inicio");
+}
+
+function cargarTablaGarantia() {
+    let data = ejecutarAjax("controladores/servicio_garantia.php", "leer=1");
+    $("#garantia_tb").html("");
+    if (data === "0") {
+        $("#garantia_tb").html("<tr><td colspan='6'>NO HAY REGISTRO</td></tr>");
+    } else {
+        let json_data = JSON.parse(data);
+        json_data.map(function (item) {
+            $("#garantia_tb").append(`
+                <tr>
+                    <td>${item.id_garantia}</td>
+                    <td>${item.id_servicio} - ${item.cliente}</td>
+                    <td>${item.fecha_inicio}</td>
+                    <td>${item.duracion_dias}</td>
+                    <td>${item.estado}</td>
+                    <td>
+                        <button class='btn btn-danger anular-garantia'>Anular</button>
+                        <button class='btn btn-primary imprimir-garantia'>Imprimir</button>
+                    </td>
+                </tr>
+            `);
+        });
+    }
+}
+
+$(document).on("click", ".anular-garantia", function () {
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    Swal.fire({
+        title: '¿Anular garantía?',
+        text: "Una vez anulada, no podrás revertir esta acción.",
+        icon: 'warning',
+        showCancelButton: true,
+        confirmButtonColor: '#d33',
+        cancelButtonColor: '#3085d6',
+        confirmButtonText: 'Sí, anular',
+        cancelButtonText: 'Cancelar'
+    }).then((result) => {
+        if (result.isConfirmed) {
+            ejecutarAjax("controladores/servicio_garantia.php", "anular=" + id);
+            cargarTablaGarantia();
+            Swal.fire('¡Anulada!', 'La garantía ha sido anulada.', 'success');
+        }
+    });
+});
+
+$(document).on("click", ".imprimir-garantia", function () {
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    imprimirGarantia(id);
+});
+
+function cargarListaServicio(componente) {
+    let data = ejecutarAjax("controladores/servicio_garantia.php", "leer_servicio=1");
+    if (data === "0") {
+        $(componente).html("<option value='0'>Sin servicios</option>");
+    } else {
+        let json_data = JSON.parse(data);
+        $(componente).html("<option value='0'>-- Seleccione un servicio --</option>");
+        json_data.map(function (item) {
+            $(componente).append(`<option value="${item.id_servicio}">${item.id_servicio} - ${item.cliente}</option>`);
+        });
+    }
+}
+
+function guardarGarantia() {
+    if ($("#servicio_lst").val() === "0") {
+        alert("Seleccione un servicio");
+        return;
+    }
+    let cab = {
+        id_servicio: $("#servicio_lst").val(),
+        fecha_inicio: $("#fecha_inicio").val(),
+        duracion_dias: $("#duracion").val(),
+        estado: 'Vigente'
+    };
+    ejecutarAjax("controladores/servicio_garantia.php", "guardar=" + JSON.stringify(cab));
+    mensaje_dialogo_info("Garantía registrada correctamente", "REGISTRADO");
+    mostrarListarGarantia();
+}
+
+function imprimirGarantia(id) {
+    window.open("paginas/movimientos/servicios/garantia/imprimir.php?id=" + id);
+}


### PR DESCRIPTION
## Summary
- add database table for service warranties
- integrate Garantia menu and pages
- implement CRUD, print, and annul actions for service warranties

## Testing
- `php -l index.php controladores/servicio_garantia.php paginas/movimientos/servicios/garantia/agregar.php paginas/movimientos/servicios/garantia/listar.php paginas/movimientos/servicios/garantia/imprimir.php`


------
https://chatgpt.com/codex/tasks/task_e_68902182856883338bf3339527b6d44b