### PR TITLE
Add Repuesto referential CRUD

### DIFF
--- a/controladores/repuesto.php
+++ b/controladores/repuesto.php
@@ -1,0 +1,65 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    $json_datos = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO `repuesto`(`nombre_repuesto`, `precio`, `estado`) VALUES (:nombre_repuesto,:precio,:estado)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer_repuesto'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_repuesto`, `nombre_repuesto`, `precio`, `estado` FROM `repuesto`");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['leer'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_repuesto`, `nombre_repuesto`, `precio`, `estado` FROM `repuesto` WHERE estado = 'ACTIVO'");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['leer_repuesto_id'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_repuesto`, `nombre_repuesto`, `precio`, `estado` FROM `repuesto` WHERE id_repuesto = :id");
+    $query->execute([
+        "id" => $_POST['leer_repuesto_id']
+    ]);
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
+
+function actualizar($lista)
+{
+    $json_datos = json_decode($lista, true);
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("UPDATE `repuesto` SET `nombre_repuesto`=:nombre_repuesto,`precio`=:precio,`estado`=:estado WHERE `id_repuesto`=:id_repuesto");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("DELETE FROM `repuesto` WHERE `id_repuesto`= :id");
+    $query->execute([
+        "id" => $_POST['eliminar']
+    ]);
+}
+

--- a/index.php
+++ b/index.php
@@ -344,6 +344,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                         </a>
                                     </li>
                                     <li class="nav-item">
+                                        <a href="#" onclick="mostrarListarRepuesto();" class="nav-link">
+                                            <i class="nav-icon bi bi-circle"></i>
+                                            <p>Repuesto</p>
+                                        </a>
+                                    </li>
+                                    <li class="nav-item">
                                         <a href="#" onclick="mostrarListarTecnico();" class="nav-link">
                                             <i class="nav-icon bi bi-circle"></i>
                                             <p>Tecnico</p>
@@ -734,6 +740,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/producto.js"></script>
         <script src="vistas/proveedor.js"></script>
         <script src="vistas/tecnico.js"></script>
+        <script src="vistas/repuesto.js"></script>
         <script src="vistas/recepcion.js"></script>
         <script src="vistas/diagnostico.js"></script>
         <script src="vistas/presupuesto_servicio.js"></script>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -355,6 +355,23 @@ INSERT INTO `proveedor` (`id_proveedor`, `nombre_proveedor`, `ruc`, `telefono`, 
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `repuesto`
+--
+
+CREATE TABLE `repuesto` (
+  `id_repuesto` int(11) NOT NULL,
+  `nombre_repuesto` varchar(100) DEFAULT NULL,
+  `precio` double DEFAULT NULL,
+  `estado` varchar(45) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+
+--
+-- Volcado de datos para la tabla `repuesto`
+--
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `tecnico`
 --
 
@@ -564,6 +581,12 @@ ALTER TABLE `proveedor`
   ADD PRIMARY KEY (`id_proveedor`);
 
 --
+-- Indices de la tabla `repuesto`
+--
+ALTER TABLE `repuesto`
+  ADD PRIMARY KEY (`id_repuesto`);
+
+--
 -- Indices de la tabla `tecnico`
 --
 ALTER TABLE `tecnico`
@@ -680,6 +703,12 @@ ALTER TABLE `producto`
 --
 ALTER TABLE `proveedor`
   MODIFY `id_proveedor` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=3;
+
+--
+-- AUTO_INCREMENT de la tabla `repuesto`
+--
+ALTER TABLE `repuesto`
+  MODIFY `id_repuesto` int(11) NOT NULL AUTO_INCREMENT;
 
 --
 -- AUTO_INCREMENT de la tabla `tecnico`

--- a/paginas/referenciales/repuesto/agregar.php
+++ b/paginas/referenciales/repuesto/agregar.php
@@ -1,0 +1,41 @@
+<?php session_start(); ?>
+<div class="container mt-4 p-4 shadow rounded bg-light" style="max-width: 950px;">
+    <input type="hidden" id="id_repuesto" value="0">
+
+    <div class="text-center mb-4">
+        <h2 class="fw-bold text-primary">Nuevo Repuesto</h2>
+        <hr>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-6">
+            <label for="nombre_repuesto" class="form-label fs-5">Nombre</label>
+            <input type="text" id="nombre_repuesto" class="form-control form-control-lg" placeholder="Ingrese el nombre">
+        </div>
+        <div class="col-md-6">
+            <label for="precio" class="form-label fs-5">Precio</label>
+            <input type="text" id="precio" class="form-control form-control-lg" placeholder="Ingrese el precio">
+        </div>
+        <div class="col-md-6">
+            <label for="estado" class="form-label fs-5">Estado</label>
+            <select id="estado" class="form-select form-select-lg">
+                <option value="ACTIVO">ACTIVO</option>
+                <option value="INACTIVO">INACTIVO</option>
+            </select>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-md-6">
+            <button class="btn btn-success btn-lg w-100" onclick="guardarRepuesto();">
+                <i class="bi bi-check-circle"></i> Guardar
+            </button>
+        </div>
+        <div class="col-md-6">
+            <button class="btn btn-outline-danger btn-lg w-100" onclick="mostrarListarRepuesto();">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>
+

--- a/paginas/referenciales/repuesto/listar.php
+++ b/paginas/referenciales/repuesto/listar.php
@@ -1,0 +1,30 @@
+<div class="container-fluid mt-4 p-4 shadow rounded bg-white">
+    <div class="row align-items-center mb-3">
+        <div class="col-md-8">
+            <h2 class="fw-bold text-secondary mb-0">🧩 Lista de Repuestos</h2>
+        </div>
+        <div class="col-md-4 text-md-end text-start mt-3 mt-md-0">
+            <button class="btn btn-primary btn-lg" onclick="mostrarAgregarRepuesto(); return false;">
+                <i class="bi bi-plus-circle"></i> Agregar Repuesto
+            </button>
+        </div>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-hover table-bordered align-middle text-center fs-5">
+            <thead class="table-dark text-white">
+                <tr>
+                    <th style="min-width: 50px;">#</th>
+                    <th style="min-width: 150px;">Nombre</th>
+                    <th style="min-width: 100px;">Precio</th>
+                    <th style="min-width: 100px;">Estado</th>
+                    <th style="min-width: 180px;">Operaciones</th>
+                </tr>
+            </thead>
+            <tbody id="repuesto_tb">
+                <!-- Se cargan los repuestos aquí -->
+            </tbody>
+        </table>
+    </div>
+</div>
+

--- a/vistas/repuesto.js
+++ b/vistas/repuesto.js
@@ -1,0 +1,93 @@
+//mostrar Lista
+function mostrarListarRepuesto() {
+    let contenido = dameContenido("paginas/referenciales/repuesto/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaRepuesto();
+}
+
+//Mostrar Agregar
+function mostrarAgregarRepuesto() {
+    let contenido = dameContenido("paginas/referenciales/repuesto/agregar.php");
+    $("#contenido-principal").html(contenido);
+}
+
+//Guardar
+function guardarRepuesto(){
+    if($("#nombre_repuesto").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debes de ingresar un nombre", "ERROR");
+        return;
+    }
+    if($("#precio").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debes de ingresar un precio", "ERROR");
+        return;
+    }
+
+    let data = {
+        'nombre_repuesto': $("#nombre_repuesto").val(),
+        'precio': $("#precio").val(),
+        'estado': $("#estado").val()
+    };
+
+    if($("#id_repuesto").val() === "0"){
+        ejecutarAjax("controladores/repuesto.php", "guardar="+JSON.stringify(data));
+        mensaje_dialogo_info("Guardado correctamente");
+    }else{
+        data = {...data, "id_repuesto": $("#id_repuesto").val()};
+        ejecutarAjax("controladores/repuesto.php", "actualizar="+JSON.stringify(data));
+        mensaje_dialogo_info("Actualizado Correctamente");
+        $("#id_repuesto").val("0");
+    }
+    mostrarListarRepuesto();
+}
+
+$(document).on("click", ".eliminar-repuesto", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    $.ajax({
+        type: "POST",
+        async: false,
+        cache: false,
+        url: "controladores/repuesto.php",
+        data: "eliminar="+id,
+        success: function(){
+            mensaje_dialogo_info("Eliminado");
+            cargarTablaRepuesto();
+        }
+    });
+});
+
+$(document).on("click", ".editar-repuesto", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    let contenido = dameContenido("paginas/referenciales/repuesto/agregar.php");
+    $("#contenido-principal").html(contenido);
+    let data = ejecutarAjax("controladores/repuesto.php", "leer_repuesto_id="+id);
+    let json_data = JSON.parse(data);
+    $("#nombre_repuesto").val(json_data.nombre_repuesto);
+    $("#precio").val(json_data.precio);
+    $("#estado").val(json_data.estado);
+    $("#id_repuesto").val(id);
+});
+
+function cargarTablaRepuesto(){
+    let data = ejecutarAjax("controladores/repuesto.php", "leer_repuesto=1");
+    if(data === "0"){
+        $("#repuesto_tb").html("");
+    }else{
+        let json_data = JSON.parse(data);
+        $("#repuesto_tb").html("");
+        json_data.map(function(item){
+            $("#repuesto_tb").append(`
+                <tr>
+                    <td>${item.id_repuesto}</td>
+                    <td>${item.nombre_repuesto}</td>
+                    <td>${item.precio}</td>
+                    <td>${item.estado}</td>
+                    <td>
+                        <button class="btn btn-warning editar-repuesto">Editar</button>
+                        <button class="btn btn-danger eliminar-repuesto">Eliminar</button>
+                    </td>
+                </tr>
+            `);
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Repuesto table to schema
- implement controller for Repuesto CRUD operations
- create Repuesto views and JavaScript handlers with navigation integration

## Testing
- `php -l controladores/repuesto.php`
- `php -l paginas/referenciales/repuesto/agregar.php`
- `php -l paginas/referenciales/repuesto/listar.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_6890229c2c248333801f449b1bf4c098