### PR TITLE
feat: add service parts and budget totals

### DIFF
--- a/controladores/servicio.php
+++ b/controladores/servicio.php
@@ -22,7 +22,7 @@ if(isset($_POST['leer'])){
 
 if(isset($_POST['leer_presupuesto'])){
     $conexion = new DB();
-    $query = $conexion->conectar()->prepare("SELECT psc.id_presupuesto_servicio, psc.fecha_presupuesto, CONCAT(c.nombre,' ',c.apellido) as cliente FROM presupuesto_servicio_cabecera psc JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente WHERE psc.estado='Aprobado' AND DATE_ADD(psc.fecha_presupuesto, INTERVAL psc.validez_dias DAY) >= CURDATE()");
+    $query = $conexion->conectar()->prepare("SELECT psc.id_presupuesto_servicio, psc.fecha_presupuesto, CONCAT(c.nombre,' ',c.apellido) as cliente, COALESCE(SUM(psd.subtotal),0) AS total FROM presupuesto_servicio_cabecera psc JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente LEFT JOIN presupuesto_servicio_detalle psd ON psd.id_presupuesto_servicio = psc.id_presupuesto_servicio WHERE psc.estado='Aprobado' AND DATE_ADD(psc.fecha_presupuesto, INTERVAL psc.validez_dias DAY) >= CURDATE() GROUP BY psc.id_presupuesto_servicio, psc.fecha_presupuesto, cliente");
     $query->execute();
     if($query->rowCount()){
         print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
@@ -68,6 +68,13 @@ if(isset($_POST['guardar_detalle'])){
     $json = json_decode($_POST['guardar_detalle'], true);
     $conexion = new DB();
     $query = $conexion->conectar()->prepare("INSERT INTO servicio_detalle(id_servicio, tarea, horas_trabajadas, observaciones) VALUES(:id_servicio, :tarea, :horas_trabajadas, :observaciones)");
+    $query->execute($json);
+}
+
+if(isset($_POST['guardar_repuesto'])){
+    $json = json_decode($_POST['guardar_repuesto'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO servicio_repuesto(id_servicio, id_repuesto, cantidad) VALUES(:id_servicio, :id_repuesto, :cantidad)");
     $query->execute($json);
 }
 

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -842,6 +842,22 @@ CREATE TABLE servicio_detalle (
 
 -- --------------------------------------------------------
 
+-- Estructura de tabla para la tabla `servicio_repuesto`
+-- --------------------------------------------------------
+CREATE TABLE servicio_repuesto (
+  id_srv_rep INT AUTO_INCREMENT PRIMARY KEY,
+  id_servicio INT NOT NULL,
+  id_repuesto INT NOT NULL,
+  cantidad INT NOT NULL DEFAULT 1,
+  CONSTRAINT fk_srvrep_srv
+    FOREIGN KEY (id_servicio)
+    REFERENCES servicio_cabecera(id_servicio)
+      ON DELETE CASCADE
+      ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
 -- Estructura de tabla para la tabla `servicio_garantia`
 -- --------------------------------------------------------
 CREATE TABLE servicio_garantia (

--- a/paginas/movimientos/servicios/servicio/agregar.php
+++ b/paginas/movimientos/servicios/servicio/agregar.php
@@ -26,6 +26,13 @@
     </div>
 
     <div class="row g-4 mb-4">
+      <div class="col-md-6">
+        <label for="precio_presupuesto" class="form-label fw-semibold text-dark">Precio Presupuesto</label>
+        <input type="number" id="precio_presupuesto" class="form-control" value="0" readonly />
+      </div>
+    </div>
+
+    <div class="row g-4 mb-4">
       <div class="col-md-12">
         <label for="observaciones" class="form-label fw-semibold text-dark">Observaciones</label>
         <input type="text" id="observaciones" class="form-control" />
@@ -66,6 +73,61 @@
         </thead>
         <tbody id="detalle_servicio_tb" class="table-group-divider text-dark"></tbody>
       </table>
+    </div>
+
+    <hr class="mb-4">
+
+    <div class="row g-3 align-items-end mb-5">
+      <div class="col-md-6">
+        <label for="repuesto_lst" class="form-label fw-semibold text-dark">Repuesto</label>
+        <select id="repuesto_lst" class="form-select">
+          <option value="0">-- Seleccione un repuesto --</option>
+        </select>
+      </div>
+      <div class="col-md-2">
+        <label for="precio_repuesto" class="form-label fw-semibold text-dark">Precio</label>
+        <input type="number" id="precio_repuesto" class="form-control" value="0" readonly />
+      </div>
+      <div class="col-md-2">
+        <label for="cantidad_repuesto" class="form-label fw-semibold text-dark">Cantidad</label>
+        <input type="number" id="cantidad_repuesto" class="form-control" value="1" min="1" />
+      </div>
+      <div class="col-md-2 text-center">
+        <button type="button" class="btn btn-primary w-100" onclick="agregarRepuestoServicio(); return false;">
+          <i class="bi bi-plus-circle me-2 fs-5"></i>
+        </button>
+      </div>
+    </div>
+
+    <div class="mb-5">
+      <table class="table table-bordered table-hover align-middle text-center">
+        <thead class="table-dark">
+          <tr>
+            <th>Repuesto</th>
+            <th>Precio</th>
+            <th>Cantidad</th>
+            <th>Subtotal</th>
+            <th>Cobrar</th>
+            <th>Acciones</th>
+          </tr>
+        </thead>
+        <tbody id="repuesto_servicio_tb" class="table-group-divider text-dark"></tbody>
+      </table>
+    </div>
+
+    <div class="row mb-5">
+      <div class="col-md-4">
+        <label class="fw-semibold text-dark">Total Presupuesto:</label>
+        <p id="total_presupuesto" class="fw-bold">0</p>
+      </div>
+      <div class="col-md-4">
+        <label class="fw-semibold text-dark">Total Repuestos:</label>
+        <p id="total_repuesto" class="fw-bold">0</p>
+      </div>
+      <div class="col-md-4">
+        <label class="fw-semibold text-dark">Total General:</label>
+        <p id="total_general" class="fw-bold">0</p>
+      </div>
     </div>
 
     <div class="row g-3">


### PR DESCRIPTION
## Summary
- show selected budget price when creating service
- track spare parts used on services and compute totals
- include spare parts in service printouts

## Testing
- `php -l controladores/servicio.php`
- `php -l paginas/movimientos/servicios/servicio/agregar.php`
- `php -l paginas/movimientos/servicios/servicio/imprimir.php`
- `node --check vistas/servicio.js`


------
https://chatgpt.com/codex/tasks/task_e_68909d924558833386678fafaa9ecea9