### PR TITLE
Validar id_usuario en módulo de compra

### DIFF
--- a/controladores/compra.php
+++ b/controladores/compra.php
@@ -20,9 +20,28 @@ if(isset($_POST['leer'])){
 
 if(isset($_POST['guardar'])){
     $json = json_decode($_POST['guardar'], true);
-    $json['id_usuario'] = $_SESSION['id_usuario'];
     $conexion = new DB();
-    $query = $conexion->conectar()->prepare("INSERT INTO compra_cabecera(fecha, observacion, id_proveedor, id_orden, total_exenta, total_iva5, total_iva10, total, id_usuario, estado) VALUES(:fecha,:observacion,:id_proveedor,:id_orden,:total_exenta,:total_iva5,:total_iva10,:total,:id_usuario,:estado)");
+    $pdo = $conexion->conectar();
+    if(!isset($_SESSION['id_usuario'])){
+        if(isset($_SESSION['usuario'])){
+            $stmt = $pdo->prepare("SELECT id_usuario FROM usuario WHERE usuario = :usuario");
+            $stmt->execute(['usuario' => $_SESSION['usuario']]);
+            $user = $stmt->fetch(PDO::FETCH_ASSOC);
+            if($user){
+                $_SESSION['id_usuario'] = $user['id_usuario'];
+            }else{
+                http_response_code(401);
+                echo 'ID de usuario no disponible';
+                exit;
+            }
+        }else{
+            http_response_code(401);
+            echo 'ID de usuario no disponible';
+            exit;
+        }
+    }
+    $json['id_usuario'] = $_SESSION['id_usuario'];
+    $query = $pdo->prepare("INSERT INTO compra_cabecera(fecha, observacion, id_proveedor, id_orden, total_exenta, total_iva5, total_iva10, total, id_usuario, estado) VALUES(:fecha,:observacion,:id_proveedor,:id_orden,:total_exenta,:total_iva5,:total_iva10,:total,:id_usuario,:estado)");
     $query->execute($json);
 //    registrarAuditoria('COMPRA', 'GUARDAR');
 }

--- a/controladores/orden_compra.php
+++ b/controladores/orden_compra.php
@@ -36,9 +36,28 @@ if(isset($_POST['leer_aprobado'])){
 
 if(isset($_POST['guardar'])){
     $json = json_decode($_POST['guardar'], true);
-    $json['id_usuario'] = $_SESSION['id_usuario'];
     $conexion = new DB();
-    $query = $conexion->conectar()->prepare("INSERT INTO orden_compra_cabecera(fecha, observacion, id_proveedor, total, id_presupuesto, id_usuario, estado) VALUES(:fecha,:observacion,:proveedor,:total,:presupuesto,:id_usuario,:estado)");
+    $pdo = $conexion->conectar();
+    if(!isset($_SESSION['id_usuario'])){
+        if(isset($_SESSION['usuario'])){
+            $stmt = $pdo->prepare("SELECT id_usuario FROM usuario WHERE usuario = :usuario");
+            $stmt->execute(['usuario' => $_SESSION['usuario']]);
+            $user = $stmt->fetch(PDO::FETCH_ASSOC);
+            if($user){
+                $_SESSION['id_usuario'] = $user['id_usuario'];
+            }else{
+                http_response_code(401);
+                echo 'ID de usuario no disponible';
+                exit;
+            }
+        }else{
+            http_response_code(401);
+            echo 'ID de usuario no disponible';
+            exit;
+        }
+    }
+    $json['id_usuario'] = $_SESSION['id_usuario'];
+    $query = $pdo->prepare("INSERT INTO orden_compra_cabecera(fecha, observacion, id_proveedor, total, id_presupuesto, id_usuario, estado) VALUES(:fecha,:observacion,:proveedor,:total,:presupuesto,:id_usuario,:estado)");
     $query->execute($json);
 }
 

--- a/controladores/pedido_proveedor.php
+++ b/controladores/pedido_proveedor.php
@@ -26,9 +26,28 @@ if(isset($_POST['leer_activo'])){
 
 if(isset($_POST['guardar'])){
     $json = json_decode($_POST['guardar'], true);
-    $json['id_usuario'] = $_SESSION['id_usuario'];
     $conexion = new DB();
-    $query = $conexion->conectar()->prepare("INSERT INTO pedido_proveedor_cabecera(fecha, observacion, id_proveedor, id_usuario, estado) VALUES(:fecha,:observacion,:proveedor,:id_usuario,:estado)");
+    $pdo = $conexion->conectar();
+    if(!isset($_SESSION['id_usuario'])){
+        if(isset($_SESSION['usuario'])){
+            $stmt = $pdo->prepare("SELECT id_usuario FROM usuario WHERE usuario = :usuario");
+            $stmt->execute(['usuario' => $_SESSION['usuario']]);
+            $user = $stmt->fetch(PDO::FETCH_ASSOC);
+            if($user){
+                $_SESSION['id_usuario'] = $user['id_usuario'];
+            }else{
+                http_response_code(401);
+                echo 'ID de usuario no disponible';
+                exit;
+            }
+        }else{
+            http_response_code(401);
+            echo 'ID de usuario no disponible';
+            exit;
+        }
+    }
+    $json['id_usuario'] = $_SESSION['id_usuario'];
+    $query = $pdo->prepare("INSERT INTO pedido_proveedor_cabecera(fecha, observacion, id_proveedor, id_usuario, estado) VALUES(:fecha,:observacion,:proveedor,:id_usuario,:estado)");
     $query->execute($json);
 }
 

--- a/controladores/presupuesto.php
+++ b/controladores/presupuesto.php
@@ -36,9 +36,28 @@ if(isset($_POST['leer_aprobado'])){
 
 if(isset($_POST['guardar'])){
     $json = json_decode($_POST['guardar'], true);
-    $json['id_usuario'] = $_SESSION['id_usuario'];
     $conexion = new DB();
-    $query = $conexion->conectar()->prepare("INSERT INTO presupuesto_cabecera(fecha, observacion, id_proveedor, total, id_usuario, estado) VALUES(:fecha,:observacion,:proveedor,:total,:id_usuario,:estado)");
+    $pdo = $conexion->conectar();
+    if(!isset($_SESSION['id_usuario'])){
+        if(isset($_SESSION['usuario'])){
+            $stmt = $pdo->prepare("SELECT id_usuario FROM usuario WHERE usuario = :usuario");
+            $stmt->execute(['usuario' => $_SESSION['usuario']]);
+            $user = $stmt->fetch(PDO::FETCH_ASSOC);
+            if($user){
+                $_SESSION['id_usuario'] = $user['id_usuario'];
+            }else{
+                http_response_code(401);
+                echo 'ID de usuario no disponible';
+                exit;
+            }
+        }else{
+            http_response_code(401);
+            echo 'ID de usuario no disponible';
+            exit;
+        }
+    }
+    $json['id_usuario'] = $_SESSION['id_usuario'];
+    $query = $pdo->prepare("INSERT INTO presupuesto_cabecera(fecha, observacion, id_proveedor, total, id_usuario, estado) VALUES(:fecha,:observacion,:proveedor,:total,:id_usuario,:estado)");
     $query->execute($json);
 }
 


### PR DESCRIPTION
## Summary
- Recuperar id_usuario del usuario logeado cuando no está en sesión
- Usar el id recuperado para asociar presupuestos, órdenes de compra y compras al usuario actual

## Testing
- `php -l controladores/presupuesto.php`
- `php -l controladores/orden_compra.php`
- `php -l controladores/compra.php`
- `php -l controladores/pedido_proveedor.php`


------
https://chatgpt.com/codex/tasks/task_e_6890a5dbca808333921b4f912572046e