### PR TITLE
feat: track service total

### DIFF
--- a/controladores/servicio.php
+++ b/controladores/servicio.php
@@ -3,7 +3,7 @@ require_once '../conexion/db.php';
 
 if(isset($_POST['leer'])){
     $conexion = new DB();
-    $query = $conexion->conectar()->prepare("SELECT sc.id_servicio, sc.id_presupuesto, sc.fecha_inicio, sc.fecha_fin, sc.estado, sc.observaciones, COALESCE(t.nombre_tecnico,'') as tecnico, CONCAT(c.nombre,' ',c.apellido) as cliente FROM servicio_cabecera sc JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto LEFT JOIN tecnico t ON t.id_tecnico = sc.id_tecnico JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente ORDER BY sc.id_servicio DESC");
+    $query = $conexion->conectar()->prepare("SELECT sc.id_servicio, sc.id_presupuesto, sc.fecha_inicio, sc.fecha_fin, sc.estado, sc.observaciones, sc.total_general, COALESCE(t.nombre_tecnico,'') as tecnico, CONCAT(c.nombre,' ',c.apellido) as cliente FROM servicio_cabecera sc JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto LEFT JOIN tecnico t ON t.id_tecnico = sc.id_tecnico JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente ORDER BY sc.id_servicio DESC");
     $query->execute();
     if($query->rowCount()){
         print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
@@ -33,7 +33,7 @@ if(isset($_POST['leer_presupuesto'])){
 if (isset($_POST['guardar'])) {
     $json_datos = json_decode($_POST['guardar'], true);
     $conexion = new DB();
-    $query = $conexion->conectar()->prepare("INSERT INTO servicio_cabecera(id_presupuesto, id_tecnico, fecha_inicio, fecha_fin, estado, observaciones) VALUES(:id_presupuesto, :id_tecnico, :fecha_inicio, :fecha_fin, :estado, :observaciones)");
+    $query = $conexion->conectar()->prepare("INSERT INTO servicio_cabecera(id_presupuesto, id_tecnico, fecha_inicio, fecha_fin, estado, observaciones, total_general) VALUES(:id_presupuesto, :id_tecnico, :fecha_inicio, :fecha_fin, :estado, :observaciones, :total_general)");
     $query->execute($json_datos);
 }
 //if(isset($_POST['guardar'])){

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -825,6 +825,7 @@ CREATE TABLE servicio_cabecera (
   fecha_fin DATETIME NULL,
   estado VARCHAR(20) NOT NULL DEFAULT 'En Proceso',
   observaciones TEXT,
+  total_general INT NOT NULL DEFAULT 0,
   CONSTRAINT fk_srv_presu
     FOREIGN KEY (id_presupuesto)
     REFERENCES presupuesto_servicio_cabecera(id_presupuesto_servicio)

--- a/paginas/movimientos/servicios/servicio/agregar.php
+++ b/paginas/movimientos/servicios/servicio/agregar.php
@@ -30,6 +30,10 @@
         <label for="precio_presupuesto" class="form-label fw-semibold text-dark">Precio Presupuesto</label>
         <input type="number" id="precio_presupuesto" class="form-control" value="0" readonly />
       </div>
+      <div class="col-md-6">
+        <label for="total_general" class="form-label fw-semibold text-dark">Total General</label>
+        <input type="number" id="total_general" class="form-control" value="0" readonly />
+      </div>
     </div>
 
     <div class="row g-4 mb-4">
@@ -126,7 +130,7 @@
       </div>
       <div class="col-md-4">
         <label class="fw-semibold text-dark">Total General:</label>
-        <p id="total_general" class="fw-bold">0</p>
+        <p id="total_general_lbl" class="fw-bold">0</p>
       </div>
     </div>
 

--- a/paginas/movimientos/servicios/servicio/imprimir.php
+++ b/paginas/movimientos/servicios/servicio/imprimir.php
@@ -5,7 +5,7 @@ $id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 if($id <= 0){
     die('ID no valido');
 }
-$query = $conexion->conectar()->prepare("SELECT sc.id_servicio, sc.fecha_inicio, sc.fecha_fin, sc.estado, sc.observaciones, sc.id_presupuesto, CONCAT(c.nombre,' ',c.apellido) as cliente, t.nombre_tecnico FROM servicio_cabecera sc JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente LEFT JOIN tecnico t ON t.id_tecnico = sc.id_tecnico WHERE sc.id_servicio = :id");
+$query = $conexion->conectar()->prepare("SELECT sc.id_servicio, sc.fecha_inicio, sc.fecha_fin, sc.estado, sc.observaciones, sc.id_presupuesto, sc.total_general, CONCAT(c.nombre,' ',c.apellido) as cliente, t.nombre_tecnico FROM servicio_cabecera sc JOIN presupuesto_servicio_cabecera psc ON psc.id_presupuesto_servicio = sc.id_presupuesto JOIN diagnostico_cabecera dc ON dc.id_diagnostico = psc.id_diagnostico JOIN recepcion_cabecera rc ON rc.id_recepcion_cabecera = dc.id_recepcion_cabecera JOIN cliente c ON c.id_cliente = rc.id_cliente LEFT JOIN tecnico t ON t.id_tecnico = sc.id_tecnico WHERE sc.id_servicio = :id");
 $query->execute(['id'=>$id]);
 $cab = $query->fetch(PDO::FETCH_OBJ);
 if(!$cab){
@@ -26,7 +26,7 @@ $total_repuesto = 0;
 foreach ($reps as $r) {
     $total_repuesto += $r->subtotal;
 }
-$total_general = $total_presupuesto + $total_repuesto;
+$total_general = $cab->total_general;
 ?>
 <!DOCTYPE html>
 <html lang="es">

--- a/paginas/movimientos/servicios/servicio/listar.php
+++ b/paginas/movimientos/servicios/servicio/listar.php
@@ -19,6 +19,7 @@
         <th>Fecha Inicio</th>
         <th>Fecha Fin</th>
         <th>Estado</th>
+        <th>Total</th>
         <th>Observaciones</th>
         <th>Operaciones</th>
       </tr>

--- a/vistas/servicio.js
+++ b/vistas/servicio.js
@@ -19,7 +19,7 @@ function cargarTablaServicio(){
     let data = ejecutarAjax("controladores/servicio.php","leer=1");
     $("#servicio_tb").html("");
     if(data === "0"){
-        $("#servicio_tb").html("<tr><td colspan='8'>NO HAY REGISTRO</td></tr>");
+        $("#servicio_tb").html("<tr><td colspan='9'>NO HAY REGISTRO</td></tr>");
     }else{
         let json = JSON.parse(data);
         json.map(function(item){
@@ -31,6 +31,7 @@ function cargarTablaServicio(){
                     <td>${item.fecha_inicio}</td>
                     <td>${item.fecha_fin || ''}</td>
                     <td>${item.estado}</td>
+                    <td>${formatearNumero(item.total_general)}</td>
                     <td>${item.observaciones || ''}</td>
                     <td>
                         <button class='btn btn-danger anular-servicio'>Anular</button>
@@ -200,13 +201,15 @@ function guardarServicio(){
         mensaje_dialogo_info_ERROR("Agregue detalle");
         return;
     }
+    let total_general = parseFloat($("#total_general").val()) || 0;
     let cab = {
         id_presupuesto: $("#presupuesto_lst").val(),
         id_tecnico: $("#tecnico_lst").val(),
         fecha_inicio: $("#fecha_inicio").val(),
         fecha_fin: $("#fecha_fin").val(),
         estado: 'En Proceso',
-        observaciones: $("#observaciones").val()
+        observaciones: $("#observaciones").val(),
+        total_general: total_general
     };
     ejecutarAjax("controladores/servicio.php","guardar="+encodeURIComponent(JSON.stringify(cab)));
     let id = ejecutarAjax("controladores/servicio.php","dameUltimoId=1");
@@ -247,5 +250,7 @@ function calcularTotales(){
     let presupuesto = parseFloat($("#precio_presupuesto").val()) || 0;
     $("#total_presupuesto").text(formatearNumero(presupuesto));
     $("#total_repuesto").text(formatearNumero(total_repuesto));
-    $("#total_general").text(formatearNumero(total_repuesto + presupuesto));
+    let total_general = total_repuesto + presupuesto;
+    $("#total_general").val(total_general);
+    $("#total_general_lbl").text(formatearNumero(total_general));
 }


### PR DESCRIPTION
## Summary
- add Total General field to service entry and listing
- persist Total General in backend and print using stored value

## Testing
- `php -l controladores/servicio.php`
- `php -l paginas/movimientos/servicios/servicio/imprimir.php`
- `php -l paginas/movimientos/servicios/servicio/agregar.php`
- `php -l paginas/movimientos/servicios/servicio/listar.php`
- `node --check vistas/servicio.js`


------
https://chatgpt.com/codex/tasks/task_e_6890a67467188333b77f99053054be69