### PR TITLE
Add delivery status handling to service payments

### DIFF
--- a/controladores/servicio_entrega.php
+++ b/controladores/servicio_entrega.php
@@ -25,8 +25,8 @@ if (isset($_POST['guardar'])) {
     $json_datos = json_decode($_POST['guardar'], true);
     $conexion = new DB();
     $query = $conexion->conectar()->prepare(
-        "INSERT INTO servicio_entrega (id_servicio, fecha_entrega, id_usuario, monto_servicio)
-        VALUES (:id_servicio, :fecha_entrega, :id_usuario, :monto_servicio)"
+        "INSERT INTO servicio_entrega (id_servicio, fecha_entrega, id_usuario, monto_servicio, estado)
+        VALUES (:id_servicio, :fecha_entrega, :id_usuario, :monto_servicio, 'PENDIENTE')"
     );
     $query->execute($json_datos);
 }
@@ -34,7 +34,7 @@ if (isset($_POST['guardar'])) {
 if (isset($_POST['leer'])) {
     $conexion = new DB();
     $query = $conexion->conectar()->prepare(
-        "SELECT se.id_entrega, se.fecha_entrega, se.monto_servicio, u.usuario, sc.id_servicio, CONCAT(c.nombre,' ',c.apellido) AS cliente
+        "SELECT se.id_entrega, se.fecha_entrega, se.monto_servicio, se.estado, u.usuario, sc.id_servicio, CONCAT(c.nombre,' ',c.apellido) AS cliente
         FROM servicio_entrega se
         JOIN usuario u ON u.id_usuario = se.id_usuario
         JOIN servicio_cabecera sc ON se.id_servicio = sc.id_servicio
@@ -66,5 +66,10 @@ if (isset($_POST['pagar'])) {
         VALUES (:id_entrega, :tipo_pago, :monto)"
     );
     $query->execute($json_datos);
+
+    $query = $conexion->conectar()->prepare(
+        "UPDATE servicio_entrega SET estado = 'PAGADO' WHERE id_entrega = :id_entrega"
+    );
+    $query->execute(['id_entrega' => $json_datos['id_entrega']]);
 }
 ?>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -970,6 +970,7 @@ CREATE TABLE servicio_entrega (
   fecha_entrega DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   id_usuario INT NOT NULL,
   monto_servicio INT NOT NULL DEFAULT 0,
+  estado VARCHAR(20) NOT NULL DEFAULT 'PENDIENTE',
   CONSTRAINT fk_ent_srv
     FOREIGN KEY (id_servicio)
     REFERENCES servicio_cabecera(id_servicio)

--- a/paginas/movimientos/servicios/entrega/listar.php
+++ b/paginas/movimientos/servicios/entrega/listar.php
@@ -17,6 +17,7 @@
         <th>Monto</th>
         <th>Fecha Entrega</th>
         <th>Usuario</th>
+        <th>Estado</th>
         <th>Operaciones</th>
       </tr>
     </thead>

--- a/vistas/entrega.js
+++ b/vistas/entrega.js
@@ -61,7 +61,12 @@ function cargarTablaEntrega() {
             fila += `<td>${formatearNumero(item.monto_servicio)}</td>`;
             fila += `<td>${item.fecha_entrega}</td>`;
             fila += `<td>${item.usuario || ''}</td>`;
-            fila += `<td><button class='btn btn-danger anular-entrega'>Anular</button> <button class='btn btn-primary imprimir-entrega'>Imprimir</button> <button class='btn btn-success pagar-entrega'>Pagar</button></td>`;
+            fila += `<td>${item.estado}</td>`;
+            let botones = `<button class='btn btn-primary imprimir-entrega'>Imprimir</button>`;
+            if(item.estado !== 'PAGADO'){
+                botones = `<button class='btn btn-danger anular-entrega'>Anular</button> ${botones} <button class='btn btn-success pagar-entrega'>Pagar</button>`;
+            }
+            fila += `<td>${botones}</td>`;
             fila += `</tr>`;
         });
     }
@@ -119,6 +124,7 @@ $(document).on("click", ".pagar-entrega", function(){
             };
             ejecutarAjax("controladores/servicio_entrega.php", "pagar=" + JSON.stringify(data));
             mensaje_dialogo_info("Pago registrado", "Exitoso");
+            cargarTablaEntrega();
         }
     });
 });


### PR DESCRIPTION
## Summary
- track delivery state in `servicio_entrega`
- show delivery state in list and hide pay/cancel when paid
- update delivery state to `PAGADO` when a payment is registered

## Testing
- `php -l controladores/servicio_entrega.php`
- `php -l paginas/movimientos/servicios/entrega/listar.php`
- `node --check vistas/entrega.js`


------
https://chatgpt.com/codex/tasks/task_e_6890bbeb789483338c3661d4d94e33bb