### PR TITLE
Add sales budget module

### DIFF
--- a/controladores/presupuesto_venta_cabecera.php
+++ b/controladores/presupuesto_venta_cabecera.php
@@ -1,0 +1,44 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['ultimo_registro'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT nro_presupuesto FROM presupuesto_venta_cabecera ORDER BY id_presupuesto_venta DESC LIMIT 1");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['guardar'])) {
+    $json_datos = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO presupuesto_venta_cabecera (nro_presupuesto, fecha_emision, fecha_vencimiento, id_cliente, condicion, estado) VALUES (:nro_presupuesto, :fecha_emision, :fecha_vencimiento, :id_cliente, :condicion, :estado)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['anular'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("UPDATE presupuesto_venta_cabecera SET estado='ANULADO' WHERE id_presupuesto_venta=:id");
+    $query->execute(['id' => $_POST['anular']]);
+}
+
+if (isset($_POST['activar'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("UPDATE presupuesto_venta_cabecera SET estado='ACTIVO' WHERE id_presupuesto_venta=:id");
+    $query->execute(['id' => $_POST['activar']]);
+}
+
+if (isset($_POST['leer'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT pv.id_presupuesto_venta, pv.nro_presupuesto, pv.fecha_emision, pv.fecha_vencimiento, pv.id_cliente, pv.estado, CONCAT(c.nombre, ' ', c.apellido) as razon_social, pv.condicion, SUM(d.cantidad * d.precio) as total FROM presupuesto_venta_cabecera pv JOIN cliente c ON c.id_cliente = pv.id_cliente JOIN presupuesto_venta_detalle d ON d.id_presupuesto_venta = pv.id_presupuesto_venta GROUP BY pv.id_presupuesto_venta ORDER BY pv.id_presupuesto_venta DESC");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+?>

--- a/controladores/presupuesto_venta_detalle.php
+++ b/controladores/presupuesto_venta_detalle.php
@@ -1,0 +1,10 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    $json_datos = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO presupuesto_venta_detalle (id_presupuesto_venta, id_producto, cantidad, precio) VALUES ((SELECT max(id_presupuesto_venta) FROM presupuesto_venta_cabecera), :id_producto, :cantidad, :precio)");
+    $query->execute($json_datos);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -410,6 +410,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                                 <p>Facturacion</p>
                                             </a>
                                         </li>
+                                        <li class="nav-item">
+                                            <a href="#" onclick="mostrarListarPresupuestoVenta();" class="nav-link">
+                                                <i class="nav-icon bi bi-circle"></i>
+                                                <p>Presupuesto</p>
+                                            </a>
+                                        </li>
                                     </ul>
                                 </li>
 
@@ -786,6 +792,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/orden_compra.js"></script>
         <script src="vistas/compra.js"></script>
         <script src="vistas/factura.js"></script>
+        <script src="vistas/presupuesto_venta.js"></script>
         <!--end::Script-->
     </body>
     <!--end::Body-->

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -132,6 +132,34 @@ DELIMITER ;
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `presupuesto_venta_cabecera`
+--
+
+CREATE TABLE `presupuesto_venta_cabecera` (
+  `id_presupuesto_venta` int(11) NOT NULL,
+  `nro_presupuesto` varchar(20) DEFAULT NULL,
+  `fecha_emision` date DEFAULT NULL,
+  `fecha_vencimiento` date DEFAULT NULL,
+  `id_cliente` int(11) NOT NULL,
+  `condicion` varchar(20) DEFAULT NULL,
+  `estado` varchar(20) DEFAULT 'ACTIVO'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+--
+-- Estructura de tabla para la tabla `presupuesto_venta_detalle`
+--
+
+CREATE TABLE `presupuesto_venta_detalle` (
+  `id_presupuesto_venta_detalle` int(11) NOT NULL,
+  `id_presupuesto_venta` int(11) NOT NULL,
+  `id_producto` int(11) NOT NULL,
+  `cantidad` int(11) NOT NULL,
+  `precio` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `equipo`
 --
 
@@ -665,6 +693,21 @@ ALTER TABLE `factura_detalle`
   ADD KEY `fk_factura_detalle_producto` (`id_producto`);
 
 --
+-- Indices de la tabla `presupuesto_venta_cabecera`
+--
+ALTER TABLE `presupuesto_venta_cabecera`
+  ADD PRIMARY KEY (`id_presupuesto_venta`),
+  ADD KEY `fk_presupuesto_venta_cliente` (`id_cliente`);
+
+--
+-- Indices de la tabla `presupuesto_venta_detalle`
+--
+ALTER TABLE `presupuesto_venta_detalle`
+  ADD PRIMARY KEY (`id_presupuesto_venta_detalle`),
+  ADD KEY `fk_presupuesto_venta_cabecera` (`id_presupuesto_venta`),
+  ADD KEY `fk_presupuesto_venta_producto` (`id_producto`);
+
+--
 -- Indices de la tabla `tecnico`
 --
 ALTER TABLE `tecnico`
@@ -817,6 +860,18 @@ ALTER TABLE `factura_cabecera`
 --
 ALTER TABLE `factura_detalle`
   MODIFY `id_factura_detalle` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT de la tabla `presupuesto_venta_cabecera`
+--
+ALTER TABLE `presupuesto_venta_cabecera`
+  MODIFY `id_presupuesto_venta` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT de la tabla `presupuesto_venta_detalle`
+--
+ALTER TABLE `presupuesto_venta_detalle`
+  MODIFY `id_presupuesto_venta_detalle` int(11) NOT NULL AUTO_INCREMENT;
 
 --
 -- Estructura de tabla para la tabla `diagnostico_cabecera`

--- a/paginas/movimientos/ventas/presupuesto/agregar.php
+++ b/paginas/movimientos/ventas/presupuesto/agregar.php
@@ -1,0 +1,86 @@
+<div class="row" style="padding: 40px;">
+    <div class="col-12">
+        <h3>Nuevo Presupuesto</h3>
+    </div>
+    <div class="col-12">
+        <hr>
+    </div>
+    <div class="col-3">
+        <label>Fecha Emisión</label>
+        <input type="date" class="form-control" id="fecha_emision">
+    </div>
+    <div class="col-3">
+        <label>Fecha Vencimiento</label>
+        <input type="date" class="form-control" id="fecha_vencimiento">
+    </div>
+    <div class="col-3">
+        <label>Nro Presupuesto</label>
+        <input type="text" class="form-control" id="nro_presupuesto">
+    </div>
+    <div class="col-3">
+        <label>Condición</label>
+        <select id="condicion" class="form-control">
+            <option value="CONTADO">CONTADO</option>
+            <option value="CREDITO">CREDITO</option>
+        </select>
+    </div>
+    <div class="col-12">
+        <label>Cliente</label>
+        <select id="cliente" class="form-control"></select>
+    </div>
+    <div class="col-12">
+        <hr>
+    </div>
+    <div class="col-5">
+        <label>Producto</label>
+        <select id="producto" class="form-control"></select>
+    </div>
+    <div class="col-2">
+        <label>Cantidad</label>
+        <input type="number" class="form-control" id="cantidad">
+    </div>
+    <div class="col-2">
+        <label>Precio</label>
+        <input type="number" readonly class="form-control" id="precio">
+    </div>
+    <div class="col-3" style="margin-top: 25px;">
+        <button onclick="agregarProductoPresupuestoVenta(); return false;" class="btn btn-primary form-control">Agregar</button>
+    </div>
+    <div class="col-12">
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Descripción</th>
+                    <th>Cantidad</th>
+                    <th>Precio</th>
+                    <th>EXENTA</th>
+                    <th>I.V.A. 5%</th>
+                    <th>I.V.A. 10%</th>
+                    <th>Operaciones</th>
+                </tr>
+            </thead>
+            <tbody id="datos_tb"></tbody>
+            <tfoot>
+                <tr>
+                    <th colspan="4">Total</th>
+                    <th id="t_exenta">0</th>
+                    <th id="t_iva5">0</th>
+                    <th id="t_iva10">0</th>
+                </tr>
+                <tr>
+                    <th>Total de I.V.A.</th>
+                    <th><span id="iva5">0</span> (I.V.A 5%)</th>
+                    <th><span id="iva10">0</span> (I.V.A 10%)</th>
+                    <th id="t_iva">0</th>
+                </tr>
+            </tfoot>
+        </table>
+    </div>
+    <div class="col-6">
+        <button class="btn btn-success form-control" onclick="guardarPresupuestoVenta(); return false;">Guardar</button>
+    </div>
+    <div class="col-6">
+        <button class="btn btn-danger form-control">Cancelar</button>
+    </div>
+</div>

--- a/paginas/movimientos/ventas/presupuesto/imprimir.php
+++ b/paginas/movimientos/ventas/presupuesto/imprimir.php
@@ -1,0 +1,96 @@
+<?php
+require_once '../../../../conexion/db.php';
+$conexion = new DB();
+$id = isset($_GET['id']) ? intval($_GET['id']) : 0;
+if($id <= 0){
+    die('ID no valido');
+}
+$query = $conexion->conectar()->prepare("SELECT c.id_presupuesto_venta, c.nro_presupuesto, c.fecha_emision, c.fecha_vencimiento, c.estado, CONCAT(cl.nombre,' ',cl.apellido) as cliente FROM presupuesto_venta_cabecera c JOIN cliente cl ON cl.id_cliente=c.id_cliente WHERE c.id_presupuesto_venta = :id");
+$query->execute(['id'=>$id]);
+$cab = $query->fetch(PDO::FETCH_OBJ);
+if(!$cab){
+    die('Presupuesto no encontrado');
+}
+$qdet = $conexion->conectar()->prepare("SELECT d.id_presupuesto_venta_detalle, d.cantidad, d.precio, p.nombre FROM presupuesto_venta_detalle d JOIN producto p ON p.id_producto=d.id_producto WHERE d.id_presupuesto_venta=:id");
+$qdet->execute(['id'=>$id]);
+$det = $qdet->fetchAll(PDO::FETCH_OBJ);
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Presupuesto Venta #<?= htmlspecialchars($cab->id_presupuesto_venta) ?></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { background-color: #f4f6fa; font-family: 'Poppins', sans-serif; color: #343a40; }
+    .budget-card { max-width: 900px; margin: 40px auto; border-radius: 12px; box-shadow: 0 8px 20px rgba(0,0,0,0.1); background-color: #fff; overflow: hidden; }
+    .budget-header { background: linear-gradient(90deg, #1d3557, #457b9d); color: #fff; padding: 24px 32px; display: flex; justify-content: space-between; align-items: center; }
+    .budget-header h3 { font-weight: 600; margin: 0; font-size: 1.75rem; }
+    .budget-body { padding: 32px; }
+    .budget-meta .col-md-4 { margin-bottom: 16px; }
+    .budget-meta p { margin: 0; font-size: 0.95rem; }
+    .table thead th { background-color: #f4f6fa; border-bottom: 2px solid #343a40; font-weight: 600; }
+    .table tbody tr:nth-child(even) { background-color: #fafafa; }
+    .no-products { padding: 50px 0; font-style: italic; color: #999; }
+    @media print { body { background: #fff; } .budget-card { box-shadow: none; margin: 0; } }
+  </style>
+</head>
+<body>
+  <div class="budget-card">
+    <div class="budget-header">
+      <div>
+        <h3>Presupuesto Venta</h3>
+        <small>#<?= htmlspecialchars($cab->id_presupuesto_venta) ?></small>
+      </div>
+      <div>
+        <span class="badge bg-danger">
+          Total: <?= number_format(array_reduce($det, function($c,$i){return $c+$i->precio*$i->cantidad;},0),0,'','.') ?> Gs.
+        </span>
+      </div>
+    </div>
+    <div class="budget-body">
+      <div class="row budget-meta">
+        <div class="col-md-4">
+          <p><strong>Emisión:</strong> <?= htmlspecialchars($cab->fecha_emision) ?></p>
+        </div>
+        <div class="col-md-4">
+          <p><strong>Vencimiento:</strong> <?= htmlspecialchars($cab->fecha_vencimiento) ?></p>
+        </div>
+        <div class="col-md-4">
+          <p><strong>Cliente:</strong> <?= htmlspecialchars($cab->cliente) ?></p>
+        </div>
+      </div>
+      <div class="table-responsive">
+        <table class="table align-middle mb-0">
+          <thead>
+            <tr>
+              <th class="text-center" style="width:60px;">#</th>
+              <th>Producto</th>
+              <th class="text-center" style="width:100px;">Cantidad</th>
+              <th class="text-end" style="width:120px;">Precio</th>
+              <th class="text-end" style="width:140px;">Subtotal</th>
+            </tr>
+          </thead>
+          <tbody>
+            <?php if (count($det) === 0): ?>
+            <tr>
+              <td colspan="5" class="text-center no-products">Sin productos</td>
+            </tr>
+            <?php else: foreach ($det as $i => $d): ?>
+            <tr>
+              <td class="text-center"><?= $i + 1 ?></td>
+              <td><?= htmlspecialchars($d->nombre) ?></td>
+              <td class="text-center"><?= intval($d->cantidad) ?></td>
+              <td class="text-end"><?= number_format($d->precio,0,'','.') ?></td>
+              <td class="text-end"><?= number_format($d->precio * $d->cantidad,0,'','.') ?></td>
+            </tr>
+            <?php endforeach; endif; ?>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <script>window.print();</script>
+</body>
+</html>

--- a/paginas/movimientos/ventas/presupuesto/listar.php
+++ b/paginas/movimientos/ventas/presupuesto/listar.php
@@ -1,0 +1,48 @@
+<div class="row">
+    <div class="col-12">
+        <h4>PRESUPUESTO</h4>
+    </div>
+    <div class="col-12">
+        <hr>
+    </div>
+    <div class="col-md-4">
+        <button onclick="mostrarNuevoPresupuestoVenta(); return false;" class="btn btn-primary">Nuevo Presupuesto</button>
+    </div>
+    <div class="col-12">
+        <hr>
+    </div>
+    <div class="col-3">
+        <label>Desde</label>
+        <input type="date" class="form-control" id="desde">
+    </div>
+    <div class="col-3">
+        <label>Hasta</label>
+        <input type="date" class="form-control" id="hasta">
+    </div>
+    <div class="col-3" style="margin-top: 25px;">
+        <button class="btn btn-secondary form-control">Buscar</button>
+    </div>
+    <div class="col-3">
+        <label>Nro Presupuesto</label>
+        <input type="text" class="form-control" id="nro_presupuesto_busqueda">
+    </div>
+
+    <div class="col-12 mt-4">
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>#</th>
+                    <th>Nro Presupuesto</th>
+                    <th>Emisión</th>
+                    <th>Vencimiento</th>
+                    <th>Cliente</th>
+                    <th>Condición</th>
+                    <th>Total</th>
+                    <th>Estado</th>
+                    <th>Operaciones</th>
+                </tr>
+            </thead>
+            <tbody id="datos_tb"></tbody>
+        </table>
+    </div>
+</div>

--- a/vistas/presupuesto_venta.js
+++ b/vistas/presupuesto_venta.js
@@ -1,0 +1,199 @@
+function mostrarListarPresupuestoVenta() {
+    let contenido = dameContenido("paginas/movimientos/ventas/presupuesto/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaPresupuestoVenta();
+    dameFechaActual("desde");
+    dameFechaActual("hasta");
+}
+
+function mostrarNuevoPresupuestoVenta() {
+    let contenido = dameContenido("paginas/movimientos/ventas/presupuesto/agregar.php");
+    $("#contenido-principal").html(contenido);
+    dameFechaActual("fecha_emision");
+    dameFechaActual("fecha_vencimiento");
+
+    let ultimo = ejecutarAjax("controladores/presupuesto_venta_cabecera.php","ultimo_registro=1");
+    if (ultimo === "0") {
+        $("#nro_presupuesto").val("0000001");
+    } else {
+        let json = JSON.parse(ultimo);
+        let nro = parseInt(json['nro_presupuesto']);
+        nro++;
+        $("#nro_presupuesto").val(nro.toString().padStart(7, '0'));
+    }
+
+    cargarListaClientes("#cliente");
+    cargarListaProductoCompra("#producto");
+}
+
+$(document).on("change", "#producto", function () {
+    let selected = $("#producto option:selected");
+
+    if (selected.val() === "0") {
+        $("#cantidad").val("1");
+        $("#precio").val("0");
+    } else {
+        $("#cantidad").val("1");
+        let precio = selected.data("precio");
+        $("#precio").val(quitarDecimalesConvertir(precio));
+    }
+});
+
+function agregarProductoPresupuestoVenta() {
+    if ($("#producto").val() === "0") {
+        mensaje_dialogo_info_ERROR("Debes seleccionar un producto");
+        return;
+    }
+
+    if ($("#precio").val().trim().length === 0 || quitarDecimalesConvertir($("#precio").val()) <= 0) {
+        mensaje_dialogo_info_ERROR("Debes ingresar un precio válido");
+        return;
+    }
+
+    if ($("#cantidad").val().trim().length === 0 || quitarDecimalesConvertir($("#cantidad").val()) <= 0) {
+        mensaje_dialogo_info_ERROR("Debes ingresar una cantidad válida");
+        return;
+    }
+
+    let repetido = false;
+    $("#datos_tb tr").each(function () {
+        if ($(this).find("td:eq(0)").text() === $("#producto").val()) {
+            repetido = true;
+        }
+    });
+
+    if (repetido) {
+        mensaje_dialogo_info_ERROR("El item ya ha sido agregado anteriormente");
+        return;
+    }
+
+    const id = $("#producto").val();
+    const nombre = $("#producto option:selected").text();
+    const precio = quitarDecimalesConvertir($("#precio").val());
+    const cantidad = quitarDecimalesConvertir($("#cantidad").val());
+    const iva = parseInt($("#producto option:selected").data("iva"));
+
+    const subtotal = precio * cantidad;
+    let exentas = 0, iva5 = 0, iva10 = 0;
+
+    if (iva === 0) exentas = subtotal;
+    else if (iva === 5) iva5 = subtotal;
+    else if (iva === 10) iva10 = subtotal;
+
+    $("#datos_tb").append(`
+        <tr>
+            <td>${id}</td>
+            <td>${nombre}</td>
+            <td>${cantidad}</td>
+            <td>${formatearNumero(precio)}</td>
+            <td>${formatearNumero(exentas)}</td>
+            <td>${formatearNumero(iva5)}</td>
+            <td>${formatearNumero(iva10)}</td>
+            <td><button class="btn btn-danger rem-item">Remover</button></td>
+        </tr>
+    `);
+
+    calcularTotalesPresupuestoVenta();
+}
+
+$(document).on("click", ".rem-item", function () {
+    $(this).closest("tr").remove();
+    calcularTotalesPresupuestoVenta();
+});
+
+function calcularTotalesPresupuestoVenta() {
+    let total_exenta = 0;
+    let total_iva5 = 0;
+    let total_iva10 = 0;
+    $("#datos_tb tr").each(function () {
+        total_exenta += quitarDecimalesConvertir($(this).find("td:eq(4)").text());
+        total_iva5 += quitarDecimalesConvertir($(this).find("td:eq(5)").text());
+        total_iva10 += quitarDecimalesConvertir($(this).find("td:eq(6)").text());
+    });
+    $("#t_exenta").text(formatearNumero(total_exenta));
+    $("#t_iva5").text(formatearNumero(total_iva5));
+    $("#t_iva10").text(formatearNumero(total_iva10));
+
+    $("#iva5").text(formatearNumero(Math.round(total_iva5 / 21)));
+    $("#iva10").text(formatearNumero(Math.round(total_iva10 / 11)));
+    $("#t_iva").text(formatearNumero(Math.round(total_iva10 / 11) + Math.round(total_iva5 / 21)));
+}
+
+function guardarPresupuestoVenta() {
+    if ($("#cliente").val() === "0") {
+        mensaje_dialogo_info_ERROR("Debes seleccionar un cliente");
+        return;
+    }
+
+    if ($("#datos_tb").html().trim().length === 0) {
+        mensaje_dialogo_info_ERROR("No hay productos");
+        return;
+    }
+
+    let cabecera = {
+        'nro_presupuesto': $("#nro_presupuesto").val(),
+        'fecha_emision': $("#fecha_emision").val(),
+        'fecha_vencimiento': $("#fecha_vencimiento").val(),
+        'id_cliente': $("#cliente").val(),
+        'condicion': $("#condicion").val(),
+        'estado': 'ACTIVO'
+    };
+    ejecutarAjax("controladores/presupuesto_venta_cabecera.php","guardar=" + JSON.stringify(cabecera));
+
+    $("#datos_tb tr").each(function () {
+        let detalle = {
+            'id_producto': $(this).find("td:eq(0)").text(),
+            'cantidad': $(this).find("td:eq(2)").text(),
+            'precio': quitarDecimalesConvertir($(this).find("td:eq(3)").text())
+        };
+        ejecutarAjax("controladores/presupuesto_venta_detalle.php","guardar=" + JSON.stringify(detalle));
+    });
+
+    mensaje_dialogo_info("Guardado Correctamente");
+    mostrarListarPresupuestoVenta();
+}
+
+function cargarTablaPresupuestoVenta() {
+    let data = ejecutarAjax("controladores/presupuesto_venta_cabecera.php","leer=1");
+    if (data !== "0") {
+        let json = JSON.parse(data);
+        $("#datos_tb").html("");
+        json.map(function (item) {
+            $("#datos_tb").append(`
+                <tr>
+                    <td>${item.id_presupuesto_venta}</td>
+                    <td>${item.nro_presupuesto}</td>
+                    <td>${item.fecha_emision}</td>
+                    <td>${item.fecha_vencimiento}</td>
+                    <td>${item.razon_social}</td>
+                    <td>${item.condicion}</td>
+                    <td>${formatearNumero(item.total)}</td>
+                    <td>${item.estado}</td>
+                    <td>
+                        <button class="btn btn-primary imprimir-presupuesto-venta">Imprimir</button>
+                        ${(item.estado === "ANULADO") ? `<button class='btn btn-success activar-presupuesto-venta'>Activar</button>` : `<button class='btn btn-danger anular-presupuesto-venta'>Anular</button>`}
+                    </td>
+                </tr>
+            `);
+        });
+    }
+}
+
+$(document).on("click", ".anular-presupuesto-venta", function () {
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    ejecutarAjax("controladores/presupuesto_venta_cabecera.php","anular=" + id);
+    cargarTablaPresupuestoVenta();
+    setTimeout(function(){alert("Presupuesto anulado");},500);
+});
+
+$(document).on("click", ".activar-presupuesto-venta", function () {
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    ejecutarAjax("controladores/presupuesto_venta_cabecera.php","activar=" + id);
+    cargarTablaPresupuestoVenta();
+    setTimeout(function(){alert("Presupuesto Activado");},500);
+});
+
+$(document).on("click", ".imprimir-presupuesto-venta", function () {
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    window.open("paginas/movimientos/ventas/presupuesto/imprimir.php?id="+id);
+});


### PR DESCRIPTION
## Summary
- add Presupuesto option under Ventas and load new script
- implement full CRUD for sales budgets and printing
- define DB tables for presupuesto_venta

## Testing
- `php -l controladores/presupuesto_venta_cabecera.php`
- `php -l controladores/presupuesto_venta_detalle.php`
- `php -l paginas/movimientos/ventas/presupuesto/imprimir.php`
- `php -l paginas/movimientos/ventas/presupuesto/agregar.php`
- `php -l paginas/movimientos/ventas/presupuesto/listar.php`
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_6890bd859ae083339d016f2770a44879