### PR TITLE
Agregar plan de pago para facturas a crédito

### DIFF
--- a/controladores/plan_pago.php
+++ b/controladores/plan_pago.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar_cabecera'])) {
+    $json_datos = json_decode($_POST['guardar_cabecera'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO plan_pago_cabecera (id_factura_cabecera, total) VALUES ((SELECT max(id_factura_cabecera) FROM factura_cabecera), :total)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['guardar_detalle'])) {
+    $json_datos = json_decode($_POST['guardar_detalle'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO plan_pago_detalle (id_plan, nro_cuota, fecha_vencimiento, monto_cuota, estado) VALUES ((SELECT max(id_plan) FROM plan_pago_cabecera), :nro_cuota, :fecha_vencimiento, :monto_cuota, 'PENDIENTE')");
+    $query->execute($json_datos);
+}
+
+?>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -431,6 +431,33 @@ DELIMITER ;
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `plan_pago_cabecera`
+--
+
+CREATE TABLE `plan_pago_cabecera` (
+  `id_plan` int(11) NOT NULL,
+  `id_factura_cabecera` int(11) NOT NULL,
+  `total` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Estructura de tabla para la tabla `plan_pago_detalle`
+--
+
+CREATE TABLE `plan_pago_detalle` (
+  `id_plan_detalle` int(11) NOT NULL,
+  `id_plan` int(11) NOT NULL,
+  `nro_cuota` int(11) NOT NULL,
+  `fecha_vencimiento` date NOT NULL,
+  `monto_cuota` int(11) NOT NULL,
+  `estado` varchar(20) DEFAULT 'PENDIENTE'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `tecnico`
 --
 
@@ -665,6 +692,20 @@ ALTER TABLE `factura_detalle`
   ADD KEY `fk_factura_detalle_producto` (`id_producto`);
 
 --
+-- Indices de la tabla `plan_pago_cabecera`
+--
+ALTER TABLE `plan_pago_cabecera`
+  ADD PRIMARY KEY (`id_plan`),
+  ADD KEY `fk_plan_factura` (`id_factura_cabecera`);
+
+--
+-- Indices de la tabla `plan_pago_detalle`
+--
+ALTER TABLE `plan_pago_detalle`
+  ADD PRIMARY KEY (`id_plan_detalle`),
+  ADD KEY `fk_plan_detalle_cabecera` (`id_plan`);
+
+--
 -- Indices de la tabla `tecnico`
 --
 ALTER TABLE `tecnico`
@@ -817,6 +858,18 @@ ALTER TABLE `factura_cabecera`
 --
 ALTER TABLE `factura_detalle`
   MODIFY `id_factura_detalle` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT de la tabla `plan_pago_cabecera`
+--
+ALTER TABLE `plan_pago_cabecera`
+  MODIFY `id_plan` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT de la tabla `plan_pago_detalle`
+--
+ALTER TABLE `plan_pago_detalle`
+  MODIFY `id_plan_detalle` int(11) NOT NULL AUTO_INCREMENT;
 
 --
 -- Estructura de tabla para la tabla `diagnostico_cabecera`

--- a/paginas/movimientos/ventas/facturacion/agregar.php
+++ b/paginas/movimientos/ventas/facturacion/agregar.php
@@ -89,3 +89,43 @@
     </div>
 </div>
 
+<div class="modal fade" id="modal-plan" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Plan de Pago</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <div class="row">
+                    <div class="col-6">
+                        <label>Fecha Venc.</label>
+                        <input type="date" id="pp-fecha" class="form-control">
+                    </div>
+                    <div class="col-6">
+                        <label>Monto</label>
+                        <input type="number" id="pp-monto" class="form-control">
+                    </div>
+                    <div class="col-12 mt-2">
+                        <button class="btn btn-primary" id="pp-agregar">Agregar cuota</button>
+                    </div>
+                </div>
+                <table class="table table-bordered mt-3">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Vencimiento</th>
+                            <th>Monto</th>
+                            <th>Operaciones</th>
+                        </tr>
+                    </thead>
+                    <tbody id="pp-detalle"></tbody>
+                </table>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+            </div>
+        </div>
+    </div>
+</div>
+


### PR DESCRIPTION
## Resumen
- Añadido modal para generar planes de pago al seleccionar condición CREDITO en facturación.
- Guardado de cuotas del plan de pago y cabecera mediante nuevo controlador.
- Incorporadas tablas `plan_pago_cabecera` y `plan_pago_detalle` en esquema SQL.

## Pruebas
- `php -l controladores/plan_pago.php`
- `php -l paginas/movimientos/ventas/facturacion/agregar.php`
- `node --check vistas/factura.js && echo 'syntax ok'`

------
https://chatgpt.com/codex/tasks/task_e_6890bf6856dc8333a19afa8cfddedee2