### PR TITLE
Agregar CRUD de cargo y menú Seguridad

### DIFF
--- a/controladores/cargo.php
+++ b/controladores/cargo.php
@@ -1,0 +1,54 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    $json_datos = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO `cargo`(`descripcion`, `estado`) VALUES (:descripcion,:estado)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer_cargo'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_cargo`, `descripcion`, `estado` FROM `cargo`");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['leer_cargo_id'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_cargo`, `descripcion`, `estado` FROM `cargo` WHERE id_cargo = :id");
+    $query->execute([
+        "id" => $_POST['leer_cargo_id']
+    ]);
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
+
+function actualizar($lista)
+{
+    $json_datos = json_decode($lista, true);
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("UPDATE `cargo` SET `descripcion`=:descripcion,`estado`=:estado WHERE `id_cargo`=:id_cargo");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("DELETE FROM `cargo` WHERE `id_cargo`= :id");
+    $query->execute([
+        "id" => $_POST['eliminar']
+    ]);
+}
+?>

--- a/index.php
+++ b/index.php
@@ -469,6 +469,24 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                 </ul>
                             </li>
 
+                            <li class="nav-item">
+                                <a href="#" class="nav-link">
+                                    <i class="nav-icon bi bi-lock"></i>
+                                    <p>
+                                        Seguridad
+                                        <i class="nav-arrow bi bi-chevron-right"></i>
+                                    </p>
+                                </a>
+                                <ul class="nav nav-treeview">
+                                    <li class="nav-item">
+                                        <a href="#" onclick="mostrarListarCargo();" class="nav-link">
+                                            <i class="nav-icon bi bi-circle"></i>
+                                            <p>Cargo</p>
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+
 
 
 
@@ -776,6 +794,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/cliente_equipo.js"></script>
         <script src="vistas/producto.js"></script>
         <script src="vistas/proveedor.js"></script>
+        <script src="vistas/cargo.js"></script>
         <script src="vistas/tecnico.js"></script>
         <script src="vistas/repuesto.js"></script>
         <script src="vistas/recepcion.js"></script>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -480,6 +480,25 @@ INSERT INTO `tecnico` (`id_tecnico`, `nombre_tecnico`, `cedula`, `telefono`, `es
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `cargo`
+--
+
+CREATE TABLE `cargo` (
+  `id_cargo` int(11) NOT NULL,
+  `descripcion` varchar(100) DEFAULT NULL,
+  `estado` varchar(45) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+
+--
+-- Volcado de datos para la tabla `cargo`
+--
+
+INSERT INTO `cargo` (`id_cargo`, `descripcion`, `estado`) VALUES
+(1, 'Administrador', 'ACTIVO');
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `recepcion_cabecera`
 --
 
@@ -714,6 +733,12 @@ ALTER TABLE `tecnico`
   ADD PRIMARY KEY (`id_tecnico`);
 
 --
+-- Indices de la tabla `cargo`
+--
+ALTER TABLE `cargo`
+  ADD PRIMARY KEY (`id_cargo`);
+
+--
 -- Indices de la tabla `recepcion_cabecera`
 --
 ALTER TABLE `recepcion_cabecera`
@@ -836,6 +861,12 @@ ALTER TABLE `repuesto`
 --
 ALTER TABLE `tecnico`
   MODIFY `id_tecnico` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
+
+--
+-- AUTO_INCREMENT de la tabla `cargo`
+--
+ALTER TABLE `cargo`
+  MODIFY `id_cargo` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 
 --
 -- AUTO_INCREMENT de la tabla `recepcion_cabecera`

--- a/paginas/referenciales/cargo/agregar.php
+++ b/paginas/referenciales/cargo/agregar.php
@@ -1,0 +1,36 @@
+<?php session_start(); ?>
+<div class="container mt-4 p-4 shadow rounded bg-light" style="max-width: 600px;">
+    <input type="hidden" id="id_cargo" value="0">
+
+    <div class="text-center mb-4">
+        <h2 class="fw-bold text-primary">Nuevo Cargo</h2>
+        <hr>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-12">
+            <label for="descripcion" class="form-label fs-5">Descripción</label>
+            <input type="text" id="descripcion" class="form-control form-control-lg" placeholder="Ingrese la descripción">
+        </div>
+        <div class="col-md-12">
+            <label for="estado" class="form-label fs-5">Estado</label>
+            <select id="estado" class="form-select form-select-lg">
+                <option value="ACTIVO">ACTIVO</option>
+                <option value="INACTIVO">INACTIVO</option>
+            </select>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-md-6">
+            <button class="btn btn-success btn-lg w-100" onclick="guardarCargo();">
+                <i class="bi bi-check-circle"></i> Guardar
+            </button>
+        </div>
+        <div class="col-md-6">
+            <button class="btn btn-outline-danger btn-lg w-100" onclick="mostrarListarCargo();">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>

--- a/paginas/referenciales/cargo/listar.php
+++ b/paginas/referenciales/cargo/listar.php
@@ -1,0 +1,28 @@
+<div class="container-fluid mt-4 p-4 shadow rounded bg-white">
+    <div class="row align-items-center mb-3">
+        <div class="col-md-8">
+            <h2 class="fw-bold text-secondary mb-0">⚙️ Lista de Cargos</h2>
+        </div>
+        <div class="col-md-4 text-md-end text-start mt-3 mt-md-0">
+            <button class="btn btn-primary btn-lg" onclick="mostrarAgregarCargo(); return false;">
+                <i class="bi bi-plus-circle"></i> Agregar Cargo
+            </button>
+        </div>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-hover table-bordered align-middle text-center fs-5">
+            <thead class="table-dark text-white">
+                <tr>
+                    <th style="min-width: 50px;">#</th>
+                    <th style="min-width: 150px;">Descripción</th>
+                    <th style="min-width: 100px;">Estado</th>
+                    <th style="min-width: 180px;">Operaciones</th>
+                </tr>
+            </thead>
+            <tbody id="cargo_tb">
+                <!-- Se cargan los cargos aquí -->
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/vistas/cargo.js
+++ b/vistas/cargo.js
@@ -1,0 +1,85 @@
+//mostrar Lista
+function mostrarListarCargo() {
+    let contenido = dameContenido("paginas/referenciales/cargo/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaCargo();
+}
+
+//Mostrar Agregar
+function mostrarAgregarCargo() {
+    let contenido = dameContenido("paginas/referenciales/cargo/agregar.php");
+    $("#contenido-principal").html(contenido);
+}
+
+//Guardar
+function guardarCargo(){
+    if($("#descripcion").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debes de ingresar una descripción", "ERROR");
+        return;
+    }
+
+    let data = {
+        'descripcion': $("#descripcion").val(),
+        'estado': $("#estado").val()
+    };
+
+    if($("#id_cargo").val() === "0"){
+        ejecutarAjax("controladores/cargo.php", "guardar="+JSON.stringify(data));
+        mensaje_dialogo_info("Guardado correctamente");
+    }else{
+        data = {...data, "id_cargo": $("#id_cargo").val()};
+        ejecutarAjax("controladores/cargo.php", "actualizar="+JSON.stringify(data));
+        mensaje_dialogo_info("Actualizado Correctamente");
+        $("#id_cargo").val("0");
+    }
+    mostrarListarCargo();
+}
+
+$(document).on("click", ".eliminar-cargo", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    $.ajax({
+        type: "POST",
+        async: false,
+        cache: false,
+        url: "controladores/cargo.php",
+        data: "eliminar="+id,
+        success: function(){
+            mensaje_dialogo_info("Eliminado");
+            cargarTablaCargo();
+        }
+    });
+});
+
+$(document).on("click", ".editar-cargo", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    let contenido = dameContenido("paginas/referenciales/cargo/agregar.php");
+    $("#contenido-principal").html(contenido);
+    let data = ejecutarAjax("controladores/cargo.php", "leer_cargo_id="+id);
+    let json_data = JSON.parse(data);
+    $("#descripcion").val(json_data.descripcion);
+    $("#estado").val(json_data.estado);
+    $("#id_cargo").val(id);
+});
+
+function cargarTablaCargo(){
+    let data = ejecutarAjax("controladores/cargo.php", "leer_cargo=1");
+    if(data === "0"){
+        $("#cargo_tb").html("");
+    }else{
+        let json_data = JSON.parse(data);
+        $("#cargo_tb").html("");
+        json_data.map(function(item){
+            $("#cargo_tb").append(`
+                <tr>
+                    <td>${item.id_cargo}</td>
+                    <td>${item.descripcion}</td>
+                    <td>${item.estado}</td>
+                    <td>
+                        <button class="btn btn-warning editar-cargo">Editar</button>
+                        <button class="btn btn-danger eliminar-cargo">Eliminar</button>
+                    </td>
+                </tr>
+            `);
+        });
+    }
+}


### PR DESCRIPTION
## Resumen
- Agrega menú Seguridad con acceso a Cargo.
- Implementa CRUD de cargos (controlador, vistas y scripts).
- Incluye tabla `cargo` en el esquema SQL.

## Pruebas
- `php -l controladores/cargo.php`
- `php -l paginas/referenciales/cargo/agregar.php`
- `php -l paginas/referenciales/cargo/listar.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_6890c0ee8488833382c1fd576fa9c610