### PR TITLE
feat: add cash register open close module

### DIFF
--- a/controladores/caja.php
+++ b/controladores/caja.php
@@ -1,0 +1,50 @@
+<?php
+session_start();
+require_once '../conexion/db.php';
+
+$accion = $_POST['accion'] ?? '';
+$idCaja = $_POST['caja'] ?? 0;
+$montoApertura = $_POST['monto_apertura'] ?? 0;
+$efectivo = $_POST['efectivo'] ?? 0;
+$tarjeta = $_POST['tarjeta'] ?? 0;
+$transferencia = $_POST['transferencia'] ?? 0;
+$total = $montoApertura + $efectivo + $tarjeta + $transferencia;
+
+$db = new DB();
+$pdo = $db->conectar();
+
+switch ($accion) {
+    case 'abrir':
+        $stmt = $pdo->prepare("INSERT INTO caja_registro(id_caja, monto_apertura, efectivo, tarjeta, transferencia, total, accion) VALUES (:id_caja, :monto_apertura, :efectivo, :tarjeta, :transferencia, :total, 'ABRIR')");
+        $stmt->execute([
+            'id_caja' => $idCaja,
+            'monto_apertura' => $montoApertura,
+            'efectivo' => $efectivo,
+            'tarjeta' => $tarjeta,
+            'transferencia' => $transferencia,
+            'total' => $total
+        ]);
+        echo 'Caja abierta correctamente';
+        break;
+    case 'cerrar':
+        $stmt = $pdo->prepare("INSERT INTO caja_registro(id_caja, monto_apertura, efectivo, tarjeta, transferencia, total, accion) VALUES (:id_caja, :monto_apertura, :efectivo, :tarjeta, :transferencia, :total, 'CERRAR')");
+        $stmt->execute([
+            'id_caja' => $idCaja,
+            'monto_apertura' => $montoApertura,
+            'efectivo' => $efectivo,
+            'tarjeta' => $tarjeta,
+            'transferencia' => $transferencia,
+            'total' => $total
+        ]);
+        echo 'Caja cerrada correctamente';
+        break;
+    case 'arqueo':
+        $stmt = $pdo->prepare("SELECT fecha, monto_apertura, efectivo, tarjeta, transferencia, total, accion FROM caja_registro WHERE id_caja = :id_caja ORDER BY fecha DESC");
+        $stmt->execute(['id_caja' => $idCaja]);
+        echo json_encode($stmt->fetchAll(PDO::FETCH_OBJ));
+        break;
+    default:
+        echo 'Acción no reconocida';
+        break;
+}
+?>

--- a/index.php
+++ b/index.php
@@ -405,6 +405,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                     </a>
                                     <ul class="nav nav-treeview">
                                         <li class="nav-item">
+                                            <a href="#" onclick="mostrarAperturaCierre();" class="nav-link">
+                                                <i class="nav-icon bi bi-circle"></i>
+                                                <p>Apertura Cierre</p>
+                                            </a>
+                                        </li>
+                                        <li class="nav-item">
                                             <a href="#" onclick="mostrarListarFactura();" class="nav-link">
                                                 <i class="nav-icon bi bi-circle"></i>
                                                 <p>Facturacion</p>
@@ -791,6 +797,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/presupuesto.js"></script>
         <script src="vistas/orden_compra.js"></script>
         <script src="vistas/compra.js"></script>
+        <script src="vistas/apertura_cierre.js"></script>
         <script src="vistas/factura.js"></script>
         <script src="vistas/presupuesto_venta.js"></script>
         <!--end::Script-->

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -1054,6 +1054,23 @@ CREATE TABLE servicio_entrega_pago (
       ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- --------------------------------------------------------
+--
+-- Estructura de tabla para la tabla `caja_registro`
+--
+CREATE TABLE `caja_registro` (
+  `id_registro` int(11) NOT NULL AUTO_INCREMENT,
+  `id_caja` int(11) NOT NULL,
+  `fecha` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `monto_apertura` decimal(10,2) NOT NULL DEFAULT 0,
+  `efectivo` decimal(10,2) NOT NULL DEFAULT 0,
+  `tarjeta` decimal(10,2) NOT NULL DEFAULT 0,
+  `transferencia` decimal(10,2) NOT NULL DEFAULT 0,
+  `total` decimal(10,2) NOT NULL DEFAULT 0,
+  `accion` varchar(20) NOT NULL,
+  PRIMARY KEY (`id_registro`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 --
 -- AUTO_INCREMENT de la tabla `servicio`
 --

--- a/paginas/movimientos/ventas/apertura_cierre/agregar.php
+++ b/paginas/movimientos/ventas/apertura_cierre/agregar.php
@@ -1,0 +1,48 @@
+<div class="container mt-4 p-4 shadow rounded bg-light" style="max-width: 700px;">
+    <div class="text-center mb-4">
+        <h2 class="fw-bold text-primary">Apertura / Cierre de Caja</h2>
+        <hr>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-6">
+            <label for="caja" class="form-label fs-5">Caja</label>
+            <select id="caja" class="form-select">
+                <option value="1">Caja 1</option>
+                <option value="2">Caja 2</option>
+            </select>
+        </div>
+        <div class="col-md-6">
+            <label for="monto_apertura" class="form-label fs-5">Monto de Apertura</label>
+            <input type="text" id="monto_apertura" class="form-control" value="0" onkeyup="format(this);" />
+        </div>
+        <div class="col-md-4">
+            <label for="efectivo" class="form-label fs-5">Efectivo</label>
+            <input type="text" id="efectivo" class="form-control" value="0" onkeyup="format(this);" />
+        </div>
+        <div class="col-md-4">
+            <label for="tarjeta" class="form-label fs-5">Tarjeta</label>
+            <input type="text" id="tarjeta" class="form-control" value="0" onkeyup="format(this);" />
+        </div>
+        <div class="col-md-4">
+            <label for="transferencia" class="form-label fs-5">Transferencia</label>
+            <input type="text" id="transferencia" class="form-control" value="0" onkeyup="format(this);" />
+        </div>
+        <div class="col-md-12">
+            <label for="total_general" class="form-label fs-5">Total General</label>
+            <input type="text" id="total_general" class="form-control" readonly />
+        </div>
+    </div>
+
+    <div class="row mt-4 g-3">
+        <div class="col-md-4">
+            <button class="btn btn-success w-100" onclick="abrirCaja();">Abrir Caja</button>
+        </div>
+        <div class="col-md-4">
+            <button class="btn btn-danger w-100" onclick="cerrarCaja();">Cerrar Caja</button>
+        </div>
+        <div class="col-md-4">
+            <button class="btn btn-secondary w-100" onclick="generarArqueoCaja();">Arqueo de Caja</button>
+        </div>
+    </div>
+</div>

--- a/vistas/apertura_cierre.js
+++ b/vistas/apertura_cierre.js
@@ -1,0 +1,44 @@
+function mostrarAperturaCierre() {
+    let contenido = dameContenido("paginas/movimientos/ventas/apertura_cierre/agregar.php");
+    $("#contenido-principal").html(contenido);
+    calcularTotalGeneralCaja();
+}
+
+$(document).on("input", "#efectivo, #tarjeta, #transferencia, #monto_apertura", function () {
+    calcularTotalGeneralCaja();
+});
+
+function calcularTotalGeneralCaja() {
+    let efectivo = quitarDecimalesConvertir($("#efectivo").val());
+    let tarjeta = quitarDecimalesConvertir($("#tarjeta").val());
+    let transferencia = quitarDecimalesConvertir($("#transferencia").val());
+    let apertura = quitarDecimalesConvertir($("#monto_apertura").val());
+    let total = efectivo + tarjeta + transferencia + apertura;
+    $("#total_general").val(formatearNumero(total));
+}
+
+function abrirCaja() {
+    let data = "accion=abrir&caja=" + $("#caja").val() +
+        "&monto_apertura=" + quitarDecimalesConvertir($("#monto_apertura").val()) +
+        "&efectivo=" + quitarDecimalesConvertir($("#efectivo").val()) +
+        "&tarjeta=" + quitarDecimalesConvertir($("#tarjeta").val()) +
+        "&transferencia=" + quitarDecimalesConvertir($("#transferencia").val());
+    let res = ejecutarAjax("controladores/caja.php", data);
+    mensaje_dialogo_info(res, "CORRECTO");
+}
+
+function cerrarCaja() {
+    let data = "accion=cerrar&caja=" + $("#caja").val() +
+        "&efectivo=" + quitarDecimalesConvertir($("#efectivo").val()) +
+        "&tarjeta=" + quitarDecimalesConvertir($("#tarjeta").val()) +
+        "&transferencia=" + quitarDecimalesConvertir($("#transferencia").val()) +
+        "&monto_apertura=" + quitarDecimalesConvertir($("#monto_apertura").val());
+    let res = ejecutarAjax("controladores/caja.php", data);
+    mensaje_dialogo_info(res, "CORRECTO");
+}
+
+function generarArqueoCaja() {
+    let data = "accion=arqueo&caja=" + $("#caja").val();
+    let res = ejecutarAjax("controladores/caja.php", data);
+    mensaje_dialogo_info(res, "CORRECTO");
+}


### PR DESCRIPTION
## Summary
- add Apertura Cierre option in Ventas menu
- implement cash register open/close page and logic
- include simple controller to handle caja actions
- persist caja openings and closings in `caja_registro` table

## Testing
- `php -l controladores/caja.php`
- `node --check vistas/apertura_cierre.js`


------
https://chatgpt.com/codex/tasks/task_e_6890c2074ea88333901ca666d3a0c359