### PR TITLE
feat(seguridad): add permiso CRUD and table

### DIFF
--- a/controladores/permiso.php
+++ b/controladores/permiso.php
@@ -1,0 +1,55 @@
+<?php
+require_once '../conexion/db.php';
+
+if (isset($_POST['guardar'])) {
+    $json_datos = json_decode($_POST['guardar'], true);
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("INSERT INTO `permiso`(`descripcion`, `estado`) VALUES (:descripcion,:estado)");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['leer_permiso'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_permiso`, `descripcion`, `estado` FROM `permiso`");
+    $query->execute();
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetchAll(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['leer_permiso_id'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("SELECT `id_permiso`, `descripcion`, `estado` FROM `permiso` WHERE id_permiso = :id");
+    $query->execute([
+        "id" => $_POST['leer_permiso_id']
+    ]);
+    if ($query->rowCount()) {
+        print_r(json_encode($query->fetch(PDO::FETCH_OBJ)));
+    } else {
+        echo "0";
+    }
+}
+
+if (isset($_POST['actualizar'])) {
+    actualizar($_POST['actualizar']);
+}
+
+function actualizar($lista)
+{
+    $json_datos = json_decode($lista, true);
+    $base_datos = new DB();
+    $query = $base_datos->conectar()->prepare("UPDATE `permiso` SET `descripcion`=:descripcion,`estado`=:estado WHERE `id_permiso`=:id_permiso");
+    $query->execute($json_datos);
+}
+
+if (isset($_POST['eliminar'])) {
+    $conexion = new DB();
+    $query = $conexion->conectar()->prepare("DELETE FROM `permiso` WHERE `id_permiso`= :id");
+    $query->execute([
+        "id" => $_POST['eliminar']
+    ]);
+}
+?>
+

--- a/index.php
+++ b/index.php
@@ -484,6 +484,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                             <p>Cargo</p>
                                         </a>
                                     </li>
+                                    <li class="nav-item">
+                                        <a href="#" onclick="mostrarListarPermiso();" class="nav-link">
+                                            <i class="nav-icon bi bi-circle"></i>
+                                            <p>Permiso</p>
+                                        </a>
+                                    </li>
                                 </ul>
                             </li>
 
@@ -795,6 +801,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/producto.js"></script>
         <script src="vistas/proveedor.js"></script>
         <script src="vistas/cargo.js"></script>
+        <script src="vistas/permiso.js"></script>
         <script src="vistas/tecnico.js"></script>
         <script src="vistas/repuesto.js"></script>
         <script src="vistas/recepcion.js"></script>

--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -526,6 +526,25 @@ INSERT INTO `cargo` (`id_cargo`, `descripcion`, `estado`) VALUES
 -- --------------------------------------------------------
 
 --
+-- Estructura de tabla para la tabla `permiso`
+--
+
+CREATE TABLE `permiso` (
+  `id_permiso` int(11) NOT NULL,
+  `descripcion` varchar(100) DEFAULT NULL,
+  `estado` varchar(45) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_swedish_ci;
+
+--
+-- Volcado de datos para la tabla `permiso`
+--
+
+INSERT INTO `permiso` (`id_permiso`, `descripcion`, `estado`) VALUES
+(1, 'Acceso total', 'ACTIVO');
+
+-- --------------------------------------------------------
+
+--
 -- Estructura de tabla para la tabla `recepcion_cabecera`
 --
 
@@ -781,6 +800,12 @@ ALTER TABLE `cargo`
   ADD PRIMARY KEY (`id_cargo`);
 
 --
+-- Indices de la tabla `permiso`
+--
+ALTER TABLE `permiso`
+  ADD PRIMARY KEY (`id_permiso`);
+
+--
 -- Indices de la tabla `recepcion_cabecera`
 --
 ALTER TABLE `recepcion_cabecera`
@@ -909,6 +934,12 @@ ALTER TABLE `tecnico`
 --
 ALTER TABLE `cargo`
   MODIFY `id_cargo` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
+
+--
+-- AUTO_INCREMENT de la tabla `permiso`
+--
+ALTER TABLE `permiso`
+  MODIFY `id_permiso` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 
 --
 -- AUTO_INCREMENT de la tabla `recepcion_cabecera`

--- a/paginas/referenciales/permiso/agregar.php
+++ b/paginas/referenciales/permiso/agregar.php
@@ -1,0 +1,37 @@
+<?php session_start(); ?>
+<div class="container mt-4 p-4 shadow rounded bg-light" style="max-width: 600px;">
+    <input type="hidden" id="id_permiso" value="0">
+
+    <div class="text-center mb-4">
+        <h2 class="fw-bold text-primary">Nuevo Permiso</h2>
+        <hr>
+    </div>
+
+    <div class="row g-3">
+        <div class="col-md-12">
+            <label for="descripcion" class="form-label fs-5">Descripción</label>
+            <input type="text" id="descripcion" class="form-control form-control-lg" placeholder="Ingrese la descripción">
+        </div>
+        <div class="col-md-12">
+            <label for="estado" class="form-label fs-5">Estado</label>
+            <select id="estado" class="form-select form-select-lg">
+                <option value="ACTIVO">ACTIVO</option>
+                <option value="INACTIVO">INACTIVO</option>
+            </select>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col-md-6">
+            <button class="btn btn-success btn-lg w-100" onclick="guardarPermiso();">
+                <i class="bi bi-check-circle"></i> Guardar
+            </button>
+        </div>
+        <div class="col-md-6">
+            <button class="btn btn-outline-danger btn-lg w-100" onclick="mostrarListarPermiso();">
+                <i class="bi bi-x-circle"></i> Cancelar
+            </button>
+        </div>
+    </div>
+</div>
+

--- a/paginas/referenciales/permiso/listar.php
+++ b/paginas/referenciales/permiso/listar.php
@@ -1,0 +1,29 @@
+<div class="container-fluid mt-4 p-4 shadow rounded bg-white">
+    <div class="row align-items-center mb-3">
+        <div class="col-md-8">
+            <h2 class="fw-bold text-secondary mb-0">⚙️ Lista de Permisos</h2>
+        </div>
+        <div class="col-md-4 text-md-end text-start mt-3 mt-md-0">
+            <button class="btn btn-primary btn-lg" onclick="mostrarAgregarPermiso(); return false;">
+                <i class="bi bi-plus-circle"></i> Agregar Permiso
+            </button>
+        </div>
+    </div>
+
+    <div class="table-responsive">
+        <table class="table table-hover table-bordered align-middle text-center fs-5">
+            <thead class="table-dark text-white">
+                <tr>
+                    <th style="min-width: 50px;">#</th>
+                    <th style="min-width: 150px;">Descripción</th>
+                    <th style="min-width: 100px;">Estado</th>
+                    <th style="min-width: 180px;">Operaciones</th>
+                </tr>
+            </thead>
+            <tbody id="permiso_tb">
+                <!-- Se cargan los permisos aquí -->
+            </tbody>
+        </table>
+    </div>
+</div>
+

--- a/vistas/permiso.js
+++ b/vistas/permiso.js
@@ -1,0 +1,86 @@
+//mostrar Lista
+function mostrarListarPermiso() {
+    let contenido = dameContenido("paginas/referenciales/permiso/listar.php");
+    $("#contenido-principal").html(contenido);
+    cargarTablaPermiso();
+}
+
+//Mostrar Agregar
+function mostrarAgregarPermiso() {
+    let contenido = dameContenido("paginas/referenciales/permiso/agregar.php");
+    $("#contenido-principal").html(contenido);
+}
+
+//Guardar
+function guardarPermiso(){
+    if($("#descripcion").val().trim().length === 0){
+        mensaje_dialogo_info_ERROR("Debes de ingresar una descripción", "ERROR");
+        return;
+    }
+
+    let data = {
+        'descripcion': $("#descripcion").val(),
+        'estado': $("#estado").val()
+    };
+
+    if($("#id_permiso").val() === "0"){
+        ejecutarAjax("controladores/permiso.php", "guardar="+JSON.stringify(data));
+        mensaje_dialogo_info("Guardado correctamente");
+    }else{
+        data = {...data, "id_permiso": $("#id_permiso").val()};
+        ejecutarAjax("controladores/permiso.php", "actualizar="+JSON.stringify(data));
+        mensaje_dialogo_info("Actualizado Correctamente");
+        $("#id_permiso").val("0");
+    }
+    mostrarListarPermiso();
+}
+
+$(document).on("click", ".eliminar-permiso", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    $.ajax({
+        type: "POST",
+        async: false,
+        cache: false,
+        url: "controladores/permiso.php",
+        data: "eliminar="+id,
+        success: function(){
+            mensaje_dialogo_info("Eliminado");
+            cargarTablaPermiso();
+        }
+    });
+});
+
+$(document).on("click", ".editar-permiso", function(){
+    let id = $(this).closest("tr").find("td:eq(0)").text();
+    let contenido = dameContenido("paginas/referenciales/permiso/agregar.php");
+    $("#contenido-principal").html(contenido);
+    let data = ejecutarAjax("controladores/permiso.php", "leer_permiso_id="+id);
+    let json_data = JSON.parse(data);
+    $("#descripcion").val(json_data.descripcion);
+    $("#estado").val(json_data.estado);
+    $("#id_permiso").val(id);
+});
+
+function cargarTablaPermiso(){
+    let data = ejecutarAjax("controladores/permiso.php", "leer_permiso=1");
+    if(data === "0"){
+        $("#permiso_tb").html("");
+    }else{
+        let json_data = JSON.parse(data);
+        $("#permiso_tb").html("");
+        json_data.map(function(item){
+            $("#permiso_tb").append(`
+                <tr>
+                    <td>${item.id_permiso}</td>
+                    <td>${item.descripcion}</td>
+                    <td>${item.estado}</td>
+                    <td>
+                        <button class="btn btn-warning editar-permiso">Editar</button>
+                        <button class="btn btn-danger eliminar-permiso">Eliminar</button>
+                    </td>
+                </tr>
+            `);
+        });
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Permiso controller and pages to Seguridad area
- wire new Permiso module into navigation and scripts
- define Permiso table with indexes and autoincrement in SQL dump

## Testing
- `php -l controladores/permiso.php paginas/referenciales/permiso/listar.php paginas/referenciales/permiso/agregar.php index.php`


------
https://chatgpt.com/codex/tasks/task_e_6890c3b26c408333b7ae0820fae79e64