### PR TITLE
Guardar factura al confirmar plan de pago

### DIFF
--- a/paginas/movimientos/ventas/facturacion/agregar.php
+++ b/paginas/movimientos/ventas/facturacion/agregar.php
@@ -124,6 +124,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                <button type="button" class="btn btn-primary" id="pp-confirmar">Confirmar</button>
             </div>
         </div>
     </div>

--- a/vistas/factura.js
+++ b/vistas/factura.js
@@ -52,6 +52,13 @@ $(document).on("change", "#condicion", function () {
 //----------------------------------------------------
 //----------------------------------------------------
 //----------------------------------------------------
+$(document).on("click", "#pp-confirmar", function () {
+    guardarFactura();
+});
+
+//----------------------------------------------------
+//----------------------------------------------------
+//----------------------------------------------------
 $(document).on("change", "#producto", function () {
     let selected = $("#producto option:selected");
 
@@ -274,6 +281,10 @@ function guardarFactura() {
 
     if ($("#datos_tb").html().trim().length === 0) {
         mensaje_dialogo_info_ERROR("No hay productos para la venta");
+        return;
+    }
+    if ($("#condicion").val() === "CREDITO" && $("#pp-detalle tr").length === 0) {
+        mensaje_dialogo_info_ERROR("Debes configurar un plan de pago");
         return;
     }
     //JSON


### PR DESCRIPTION
## Summary
- Agrega botón Confirmar en el modal de plan de pago
- Llama a `guardarFactura` al confirmar el plan y valida cuotas

## Testing
- `php -l paginas/movimientos/ventas/facturacion/agregar.php`
- `node --check vistas/factura.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_6890c416d26c8333a203c51b160c83af