### PR TITLE
Mantener estado de caja abierta

### DIFF
--- a/controladores/caja.php
+++ b/controladores/caja.php
@@ -43,6 +43,12 @@ switch ($accion) {
         $stmt->execute(['id_caja' => $idCaja]);
         echo json_encode($stmt->fetchAll(PDO::FETCH_OBJ));
         break;
+    case 'estado':
+        $stmt = $pdo->prepare("SELECT monto_apertura, efectivo, tarjeta, transferencia, total, accion FROM caja_registro WHERE id_caja = :id_caja ORDER BY fecha DESC LIMIT 1");
+        $stmt->execute(['id_caja' => $idCaja]);
+        $res = $stmt->fetch(PDO::FETCH_ASSOC);
+        echo json_encode($res ?: []);
+        break;
     default:
         echo 'Acción no reconocida';
         break;

--- a/paginas/movimientos/ventas/apertura_cierre/agregar.php
+++ b/paginas/movimientos/ventas/apertura_cierre/agregar.php
@@ -36,10 +36,10 @@
 
     <div class="row mt-4 g-3">
         <div class="col-md-4">
-            <button class="btn btn-success w-100" onclick="abrirCaja();">Abrir Caja</button>
+            <button id="abrir-btn" class="btn btn-success w-100" onclick="abrirCaja();">Abrir Caja</button>
         </div>
         <div class="col-md-4">
-            <button class="btn btn-danger w-100" onclick="cerrarCaja();">Cerrar Caja</button>
+            <button id="cerrar-btn" class="btn btn-danger w-100" onclick="cerrarCaja();">Cerrar Caja</button>
         </div>
         <div class="col-md-4">
             <button class="btn btn-secondary w-100" onclick="generarArqueoCaja();">Arqueo de Caja</button>

--- a/vistas/apertura_cierre.js
+++ b/vistas/apertura_cierre.js
@@ -2,10 +2,15 @@ function mostrarAperturaCierre() {
     let contenido = dameContenido("paginas/movimientos/ventas/apertura_cierre/agregar.php");
     $("#contenido-principal").html(contenido);
     calcularTotalGeneralCaja();
+    verificarEstadoCaja();
 }
 
 $(document).on("input", "#efectivo, #tarjeta, #transferencia, #monto_apertura", function () {
     calcularTotalGeneralCaja();
+});
+
+$(document).on("change", "#caja", function () {
+    verificarEstadoCaja();
 });
 
 function calcularTotalGeneralCaja() {
@@ -17,6 +22,34 @@ function calcularTotalGeneralCaja() {
     $("#total_general").val(formatearNumero(total));
 }
 
+function verificarEstadoCaja() {
+    let datos = ejecutarAjax("controladores/caja.php", "accion=estado&caja=" + $("#caja").val());
+    let info = {};
+    try {
+        info = JSON.parse(datos);
+    } catch (e) {
+        info = {};
+    }
+
+    if (info.accion === "ABRIR") {
+        $("#monto_apertura").val(formatearNumero(info.monto_apertura));
+        $("#efectivo").val(formatearNumero(info.efectivo));
+        $("#tarjeta").val(formatearNumero(info.tarjeta));
+        $("#transferencia").val(formatearNumero(info.transferencia));
+        $("#total_general").val(formatearNumero(info.total));
+        $("#abrir-btn").hide();
+        $("#cerrar-btn").show();
+    } else {
+        $("#monto_apertura").val("0");
+        $("#efectivo").val("0");
+        $("#tarjeta").val("0");
+        $("#transferencia").val("0");
+        calcularTotalGeneralCaja();
+        $("#abrir-btn").show();
+        $("#cerrar-btn").hide();
+    }
+}
+
 function abrirCaja() {
     let data = "accion=abrir&caja=" + $("#caja").val() +
         "&monto_apertura=" + quitarDecimalesConvertir($("#monto_apertura").val()) +
@@ -25,6 +58,7 @@ function abrirCaja() {
         "&transferencia=" + quitarDecimalesConvertir($("#transferencia").val());
     let res = ejecutarAjax("controladores/caja.php", data);
     mensaje_dialogo_info(res, "CORRECTO");
+    verificarEstadoCaja();
 }
 
 function cerrarCaja() {
@@ -35,6 +69,7 @@ function cerrarCaja() {
         "&monto_apertura=" + quitarDecimalesConvertir($("#monto_apertura").val());
     let res = ejecutarAjax("controladores/caja.php", data);
     mensaje_dialogo_info(res, "CORRECTO");
+    verificarEstadoCaja();
 }
 
 function generarArqueoCaja() {


### PR DESCRIPTION
## Summary
- Agrega IDs a los botones de apertura y cierre de caja para poder alternarlos dinámicamente.
- Implementa `estado` en el controlador de caja para consultar el último movimiento.
- Añade verificación en el JS de apertura/cierre que rellena montos, oculta o muestra botones y actualiza tras abrir o cerrar.

## Testing
- `php -l controladores/caja.php`
- `node --check vistas/apertura_cierre.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_6890c74018c483339024c0eeceb0e48d