### PR TITLE
Add report generation menu and form

### DIFF
--- a/index.php
+++ b/index.php
@@ -504,6 +504,12 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                     </li>
                                 </ul>
                             </li>
+                            <li class="nav-item">
+                                <a href="#" onclick="mostrarFormReportes();" class="nav-link">
+                                    <i class="nav-icon bi bi-file-earmark-text"></i>
+                                    <p>Reportes</p>
+                                </a>
+                            </li>
 
 
 
@@ -833,6 +839,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.all.min.js
         <script src="vistas/apertura_cierre.js"></script>
         <script src="vistas/factura.js"></script>
         <script src="vistas/presupuesto_venta.js"></script>
+        <script src="vistas/reporte.js"></script>
         <!--end::Script-->
     </body>
     <!--end::Body-->

--- a/paginas/reportes/formulario.php
+++ b/paginas/reportes/formulario.php
@@ -1,0 +1,66 @@
+<?php
+?>
+<div class="container mt-4">
+    <h4>Generar reporte</h4>
+    <form id="formReporte" action="paginas/reportes/generar.php" method="get" target="_blank">
+        <div class="mb-3">
+            <label for="tipo_reporte" class="form-label">Tipo de reporte</label>
+            <select class="form-select" id="tipo_reporte" name="tipo">
+                <option value="compras">Compras</option>
+                <option value="ventas">Ventas</option>
+                <option value="servicios">Servicios</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label for="modulo" class="form-label">Módulo</label>
+            <select class="form-select" id="modulo" name="modulo"></select>
+        </div>
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                <label for="desde" class="form-label">Desde</label>
+                <input type="date" class="form-control" id="desde" name="desde" required>
+            </div>
+            <div class="col-md-6 mb-3">
+                <label for="hasta" class="form-label">Hasta</label>
+                <input type="date" class="form-control" id="hasta" name="hasta" required>
+            </div>
+        </div>
+        <button type="submit" class="btn btn-primary">Generar</button>
+    </form>
+</div>
+<script>
+const opciones = {
+    compras: [
+        'Pedido Proveedor',
+        'Presupuesto',
+        'Orden de Compra',
+        'Factura de Compra'
+    ],
+    ventas: [
+        'Apertura Cierre',
+        'Facturación',
+        'Presupuesto'
+    ],
+    servicios: [
+        'Recepción',
+        'Diagnóstico',
+        'Presupuesto Servicio',
+        'Servicio',
+        'Entrega',
+        'Garantía'
+    ]
+};
+const tipo = document.getElementById('tipo_reporte');
+const modulo = document.getElementById('modulo');
+function cargarModulos(){
+    modulo.innerHTML='';
+    opciones[tipo.value].forEach(m => {
+        const opt=document.createElement('option');
+        opt.value=m.toLowerCase().replace(/ /g,'_');
+        opt.textContent=m;
+        modulo.appendChild(opt);
+    });
+}
+tipo.addEventListener('change', cargarModulos);
+cargarModulos();
+</script>

--- a/paginas/reportes/generar.php
+++ b/paginas/reportes/generar.php
@@ -1,0 +1,21 @@
+<?php
+$tipo = $_GET['tipo'] ?? '';
+$modulo = $_GET['modulo'] ?? '';
+$desde = $_GET['desde'] ?? '';
+$hasta = $_GET['hasta'] ?? '';
+?>
+<!doctype html>
+<html lang="es">
+<head>
+    <meta charset="utf-8" />
+    <title>Reporte</title>
+    <link rel="stylesheet" href="../../dist/css/adminlte.css" />
+</head>
+<body class="p-4">
+    <h3>Reporte generado</h3>
+    <p><strong>Tipo:</strong> <?php echo htmlspecialchars($tipo); ?></p>
+    <p><strong>Módulo:</strong> <?php echo htmlspecialchars($modulo); ?></p>
+    <p><strong>Desde:</strong> <?php echo htmlspecialchars($desde); ?></p>
+    <p><strong>Hasta:</strong> <?php echo htmlspecialchars($hasta); ?></p>
+</body>
+</html>

--- a/vistas/reporte.js
+++ b/vistas/reporte.js
@@ -1,0 +1,4 @@
+function mostrarFormReportes(){
+    let contenido = dameContenido("paginas/reportes/formulario.php");
+    $("#contenido-principal").html(contenido);
+}


### PR DESCRIPTION
## Summary
- Add 'Reportes' sidebar entry to access new reporting tools.
- Include frontend logic and form to pick report type, module, and date range.
- Create basic report output page displayed in a new tab.

## Testing
- `php -l index.php`
- `php -l paginas/reportes/formulario.php`
- `php -l paginas/reportes/generar.php`


------
https://chatgpt.com/codex/tasks/task_e_6890caa9f14c83339542318083650028