### PR TITLE
Use form inputs for cash audit print

### DIFF
--- a/paginas/movimientos/ventas/apertura_cierre/imprimir.php
+++ b/paginas/movimientos/ventas/apertura_cierre/imprimir.php
@@ -2,11 +2,33 @@
 require_once '../../../../conexion/db.php';
 
 $caja = isset($_GET['caja']) ? intval($_GET['caja']) : 0;
-$db = new DB();
-$pdo = $db->conectar();
-$stmt = $pdo->prepare("SELECT fecha, accion, monto_apertura, efectivo, tarjeta, transferencia, total FROM caja_registro WHERE id_caja = :id_caja ORDER BY fecha DESC");
-$stmt->execute(['id_caja' => $caja]);
-$registros = $stmt->fetchAll(PDO::FETCH_OBJ);
+$hasInputs = isset(
+    $_GET['monto_apertura'],
+    $_GET['efectivo'],
+    $_GET['tarjeta'],
+    $_GET['transferencia'],
+    $_GET['total']
+);
+
+if ($hasInputs) {
+    $registros = [
+        (object) [
+            'fecha' => date('Y-m-d H:i:s'),
+            'accion' => 'ARQUEO',
+            'monto_apertura' => intval($_GET['monto_apertura']),
+            'efectivo' => intval($_GET['efectivo']),
+            'tarjeta' => intval($_GET['tarjeta']),
+            'transferencia' => intval($_GET['transferencia']),
+            'total' => intval($_GET['total'])
+        ]
+    ];
+} else {
+    $db = new DB();
+    $pdo = $db->conectar();
+    $stmt = $pdo->prepare("SELECT fecha, accion, monto_apertura, efectivo, tarjeta, transferencia, total FROM caja_registro WHERE id_caja = :id_caja ORDER BY fecha DESC");
+    $stmt->execute(['id_caja' => $caja]);
+    $registros = $stmt->fetchAll(PDO::FETCH_OBJ);
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">

--- a/vistas/apertura_cierre.js
+++ b/vistas/apertura_cierre.js
@@ -74,8 +74,13 @@ function cerrarCaja() {
 }
 
 function generarArqueoCaja() {
-    let data = "accion=arqueo&caja=" + $("#caja").val();
-    let res = ejecutarAjax("controladores/caja.php", data);
-    mensaje_dialogo_info(res, "CORRECTO");
-    window.open("paginas/movimientos/ventas/apertura_cierre/imprimir.php?caja=" + $("#caja").val());
+    let params = new URLSearchParams({
+        caja: $("#caja").val(),
+        monto_apertura: quitarDecimalesConvertir($("#monto_apertura").val()),
+        efectivo: quitarDecimalesConvertir($("#efectivo").val()),
+        tarjeta: quitarDecimalesConvertir($("#tarjeta").val()),
+        transferencia: quitarDecimalesConvertir($("#transferencia").val()),
+        total: quitarDecimalesConvertir($("#total_general").val())
+    });
+    window.open("paginas/movimientos/ventas/apertura_cierre/imprimir.php?" + params.toString());
 }


### PR DESCRIPTION
## Summary
- Send cash audit form values directly to print page and remove modal popup
- Allow print page to render passed values or fall back to database data

## Testing
- `php -l paginas/movimientos/ventas/apertura_cierre/imprimir.php`
- `node --check vistas/apertura_cierre.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_6890e036644083338f593ec8040a9905