### PR TITLE
Registrar usuario en apertura de caja

### DIFF
--- a/lele_cell.sql
+++ b/lele_cell.sql
@@ -1195,6 +1195,7 @@ CREATE TABLE servicio_entrega_pago (
 CREATE TABLE `caja_registro` (
   `id_registro` int(11) NOT NULL AUTO_INCREMENT,
   `id_caja` int(11) NOT NULL,
+  `id_usuario` int(11) NOT NULL,
   `fecha` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `monto_apertura` decimal(10,2) NOT NULL DEFAULT 0,
   `efectivo` decimal(10,2) NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary
- Añade `id_usuario` al registro de caja y consulta el usuario activo antes de operar.
- Inserta y filtra las aperturas/cierres de caja por usuario.
- Muestra el usuario responsable en el reporte de caja.

## Testing
- `php -l controladores/caja.php`
- `php -l paginas/movimientos/ventas/apertura_cierre/imprimir.php`


------
https://chatgpt.com/codex/tasks/task_e_6890e1e9ce08833385b20085fe2cb3f4