### PR TITLE
Restrict menu options by user role

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,6 +4,7 @@ if (!isset($_SESSION['usuario'])) {
     header('Location: login.php');
     exit;
 }
+$idCargo = $_SESSION['id_cargo'] ?? null;
 ?>
 <!doctype html>
 <html lang="en">
@@ -304,6 +305,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                             role="menu"
                             data-accordion="false"
                             >
+                            <?php if ($idCargo == 1): ?>
                             <li class="nav-item">
                                 <a href="#" class="nav-link">
                                     <i class="nav-icon bi bi-speedometer"></i>
@@ -357,6 +359,7 @@ https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
                                     </li>
                                 </ul>
                             </li>
+                            <?php endif; ?>
                               <li class="nav-item">
                                     <a href="#" class="nav-link">
                                         <i class="nav-icon bi bi-cart"></i>

--- a/login.php
+++ b/login.php
@@ -18,6 +18,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($user) {
         $_SESSION['usuario'] = $user['usuario'];
         $_SESSION['id_usuario'] = $user['id_usuario'];
+        $_SESSION['id_cargo'] = $user['id_cargo'];
         header('Location: index.php');
         exit;
     } else {


### PR DESCRIPTION
## Summary
- save user role in session on login
- show Referencial menu only to administrators

## Testing
- `php -l login.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_6890e261dbc4833387972b44bf3176b9