### PR TITLE
Restringir facturacion y pago sin apertura

### DIFF
--- a/controladores/factura_cabecera.php
+++ b/controladores/factura_cabecera.php
@@ -23,8 +23,12 @@ limit 1");
 //--------------------------------------------------------------------------------
 //--------------------------------------------------------------------------------
 if (isset($_POST['guardar'])) {
+    if (!isset($_SESSION['id_apertura'])) {
+        echo "NO_APERTURA";
+        exit;
+    }
     $json_datos = json_decode($_POST['guardar'], true);
-    $json_datos['id_registro'] = $_SESSION['id_apertura'] ?? null;
+    $json_datos['id_registro'] = $_SESSION['id_apertura'];
     $conexion = new DB();
     $query = $conexion->conectar()->prepare("INSERT INTO factura_cabecera"
             . "( nro_factura, fecha, id_cliente, condicion, tipo_pago,"
@@ -33,7 +37,7 @@ if (isset($_POST['guardar'])) {
             . " :condicion, :tipo_pago, :timbrado, :estado, :id_registro)");
 
     $query->execute($json_datos);
-
+    echo "OK";
 
 }
 //--------------------------------------------------------------------------------

--- a/controladores/servicio_entrega.php
+++ b/controladores/servicio_entrega.php
@@ -60,8 +60,12 @@ if (isset($_POST['anular'])) {
 }
 
 if (isset($_POST['pagar'])) {
+    if (!isset($_SESSION['id_apertura'])) {
+        echo "NO_APERTURA";
+        exit;
+    }
     $json_datos = json_decode($_POST['pagar'], true);
-    $json_datos['id_registro'] = $_SESSION['id_apertura'] ?? null;
+    $json_datos['id_registro'] = $_SESSION['id_apertura'];
     $conexion = new DB();
     $query = $conexion->conectar()->prepare(
         "INSERT INTO servicio_entrega_pago (id_entrega, tipo_pago, monto, id_registro)
@@ -73,6 +77,7 @@ if (isset($_POST['pagar'])) {
         "UPDATE servicio_entrega SET estado = 'PAGADO' WHERE id_entrega = :id_entrega"
     );
     $query->execute(['id_entrega' => $json_datos['id_entrega']]);
+    echo "OK";
 }
 ?>
 

--- a/vistas/entrega.js
+++ b/vistas/entrega.js
@@ -122,7 +122,11 @@ $(document).on("click", ".pagar-entrega", function(){
                 tipo_pago: result.value,
                 monto: quitarDecimalesConvertir(monto)
             };
-            ejecutarAjax("controladores/servicio_entrega.php", "pagar=" + JSON.stringify(data));
+            let res = ejecutarAjax("controladores/servicio_entrega.php", "pagar=" + JSON.stringify(data));
+            if(res === "NO_APERTURA"){
+                mensaje_dialogo_info_ERROR("Debe realizar una apertura de caja", "ATENCION");
+                return;
+            }
             mensaje_dialogo_info("Pago registrado", "Exitoso");
             cargarTablaEntrega();
         }

--- a/vistas/factura.js
+++ b/vistas/factura.js
@@ -307,6 +307,10 @@ function guardarFactura() {
     };
     let res = ejecutarAjax("controladores/factura_cabecera.php",
             "guardar=" + JSON.stringify(cabecera));
+    if (res === "NO_APERTURA") {
+        mensaje_dialogo_info_ERROR("Debe realizar una apertura de caja", "ATENCION");
+        return;
+    }
     console.log(res);
 
     //detalle


### PR DESCRIPTION
## Summary
- Agregar validación de apertura de caja al guardar facturas y pagos de servicio
- Mostrar mensaje de error en la UI si no hay apertura para facturar o pagar

## Testing
- `php -l controladores/factura_cabecera.php`
- `php -l controladores/servicio_entrega.php`
- `node --check vistas/factura.js`
- `node --check vistas/entrega.js`


------
https://chatgpt.com/codex/tasks/task_e_6890f16294688333b8b1d4fa42c312b7