### PR TITLE
Add dashboard for daily metrics

### DIFF
--- a/controladores/dashboard.php
+++ b/controladores/dashboard.php
@@ -1,0 +1,52 @@
+<?php
+
+require_once '../conexion/db.php';
+
+if (isset($_POST['totales'])) {
+    $db = new DB();
+    $pdo = $db->conectar();
+
+    $sqlRecep = "SELECT COUNT(*) AS total FROM recepcion_cabecera WHERE DATE(fecha) = CURDATE() AND estado <> 'ANULADO'";
+    $queryRecep = $pdo->prepare($sqlRecep);
+    $queryRecep->execute();
+    $recepciones = $queryRecep->fetch(PDO::FETCH_ASSOC)['total'];
+
+    $sqlVentas = "SELECT COUNT(*) AS total FROM factura_cabecera WHERE DATE(fecha) = CURDATE() AND estado <> 'ANULADO'";
+    $queryVentas = $pdo->prepare($sqlVentas);
+    $queryVentas->execute();
+    $ventas = $queryVentas->fetch(PDO::FETCH_ASSOC)['total'];
+
+    echo json_encode([
+        'recepciones' => (int)$recepciones,
+        'ventas' => (int)$ventas,
+    ]);
+}
+
+if (isset($_POST['grafico'])) {
+    $db = new DB();
+    $pdo = $db->conectar();
+
+    $fechas = [];
+    $recepciones = [];
+    $ventas = [];
+
+    for ($i = 6; $i >= 0; $i--) {
+        $fecha = date('Y-m-d', strtotime("-$i day"));
+        $fechas[] = $fecha;
+
+        $stmtRecep = $pdo->prepare("SELECT COUNT(*) AS total FROM recepcion_cabecera WHERE DATE(fecha) = :fecha AND estado <> 'ANULADO'");
+        $stmtRecep->execute(['fecha' => $fecha]);
+        $recepciones[] = (int)$stmtRecep->fetch(PDO::FETCH_ASSOC)['total'];
+
+        $stmtVentas = $pdo->prepare("SELECT COUNT(*) AS total FROM factura_cabecera WHERE DATE(fecha) = :fecha AND estado <> 'ANULADO'");
+        $stmtVentas->execute(['fecha' => $fecha]);
+        $ventas[] = (int)$stmtVentas->fetch(PDO::FETCH_ASSOC)['total'];
+    }
+
+    echo json_encode([
+        'fechas' => $fechas,
+        'recepciones' => $recepciones,
+        'ventas' => $ventas,
+    ]);
+}
+

--- a/index.php
+++ b/index.php
@@ -559,7 +559,35 @@ $nombre = $_SESSION['usuario'] ?? null;
                             <!--begin::App Content-->
                             <div class="app-content" id="contenido-principal">
                                 <!--begin::Container-->
-
+                                <div class="container-fluid">
+                                    <div class="row g-4">
+                                        <div class="col-md-6 col-lg-3">
+                                            <div class="card text-bg-info">
+                                                <div class="card-body">
+                                                    <h5 class="card-title">Recepciones hoy</h5>
+                                                    <p class="card-text fs-2" id="recepciones_hoy">0</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-6 col-lg-3">
+                                            <div class="card text-bg-success">
+                                                <div class="card-body">
+                                                    <h5 class="card-title">Ventas hoy</h5>
+                                                    <p class="card-text fs-2" id="ventas_hoy">0</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row g-4 mt-1">
+                                        <div class="col-12">
+                                            <div class="card">
+                                                <div class="card-body">
+                                                    <div id="grafico-recepciones-ventas"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                                 <!--end::Container-->
                             </div>
                             <!--end::App Content-->
@@ -825,6 +853,7 @@ $nombre = $_SESSION['usuario'] ?? null;
                 </script>
                 <script src="jquery-3.7.1.min.js"></script>
                 <script src="vistas/util.js"></script>
+                <script src="vistas/dashboard.js"></script>
                 <script src="vistas/cliente.js"></script>
                 <script src="vistas/equipo.js"></script>
                 <script src="vistas/cliente_equipo.js"></script>

--- a/vistas/dashboard.js
+++ b/vistas/dashboard.js
@@ -1,0 +1,61 @@
+$(document).ready(function () {
+  cargarTotales();
+  cargarGrafico();
+});
+
+function cargarTotales() {
+  $.ajax({
+    url: 'controladores/dashboard.php',
+    type: 'POST',
+    data: { totales: true },
+    success: function (res) {
+      try {
+        var data = JSON.parse(res);
+        $('#recepciones_hoy').text(data.recepciones);
+        $('#ventas_hoy').text(data.ventas);
+      } catch (e) {
+        console.error('Error parseando totales', e);
+      }
+    },
+  });
+}
+
+function cargarGrafico() {
+  $.ajax({
+    url: 'controladores/dashboard.php',
+    type: 'POST',
+    data: { grafico: true },
+    success: function (res) {
+      try {
+        var data = JSON.parse(res);
+        var options = {
+          chart: {
+            type: 'bar',
+            height: 350,
+          },
+          series: [
+            {
+              name: 'Recepciones',
+              data: data.recepciones,
+            },
+            {
+              name: 'Ventas',
+              data: data.ventas,
+            },
+          ],
+          xaxis: {
+            categories: data.fechas,
+          },
+        };
+        var chart = new ApexCharts(
+          document.querySelector('#grafico-recepciones-ventas'),
+          options
+        );
+        chart.render();
+      } catch (e) {
+        console.error('Error parseando grafico', e);
+      }
+    },
+  });
+}
+


### PR DESCRIPTION
## Summary
- show today's receptions, sales and weekly chart on home page
- add controller providing counts for dashboard
- load dashboard script to render metrics

## Testing
- `php -l index.php`
- `php -l controladores/dashboard.php`
- `node --check vistas/dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68910b101e648333a160eb1fe74db894