### PR TITLE
Refine report layout and hide auxiliary IDs

### DIFF
--- a/paginas/reportes/generar.php
+++ b/paginas/reportes/generar.php
@@ -102,6 +102,7 @@ $config = [
 ];
 
 $headers = [];
+$columns = [];
 $error = '';
 
 if (isset($config[$tipo][$modulo])) {
@@ -116,6 +117,12 @@ if (isset($config[$tipo][$modulo])) {
     $stmt = $pdo->prepare($sqlCab);
     $stmt->execute(['desde' => $desde, 'hasta' => $hasta]);
     $headers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if ($headers) {
+        $columns = array_keys($headers[0]);
+        $columns = array_filter($columns, function($col) use ($conf) {
+            return !(strpos($col, 'id_') === 0 && $col !== $conf['id']);
+        });
+    }
 } else {
     $error = 'Módulo no soportado';
 }
@@ -128,39 +135,53 @@ if (isset($config[$tipo][$modulo])) {
     <link rel="stylesheet" href="../../dist/css/adminlte.css" />
 </head>
 <body class="p-4">
-    <h3>Reporte generado</h3>
-    <p><strong>Tipo:</strong> <?= htmlspecialchars($tipo) ?></p>
-    <p><strong>Módulo:</strong> <?= htmlspecialchars($modulo) ?></p>
-    <p><strong>Desde:</strong> <?= htmlspecialchars($desde) ?></p>
-    <p><strong>Hasta:</strong> <?= htmlspecialchars($hasta) ?></p>
+    <div class="container">
+        <div class="card">
+            <div class="card-header bg-primary text-white">
+                <h3 class="mb-0">Reporte generado</h3>
+            </div>
+            <div class="card-body">
+                <p><strong>Tipo:</strong> <?= htmlspecialchars($tipo) ?></p>
+                <p><strong>Módulo:</strong> <?= htmlspecialchars($modulo) ?></p>
+                <p><strong>Desde:</strong> <?= htmlspecialchars($desde) ?></p>
+                <p><strong>Hasta:</strong> <?= htmlspecialchars($hasta) ?></p>
 
-    <?php if ($error): ?>
-        <p><?= htmlspecialchars($error) ?></p>
-    <?php else: ?>
-        <?php if ($headers): ?>
-            <h4>Cabecera</h4>
-            <table class="table table-bordered">
-                <tr>
-                    <?php foreach (array_keys($headers[0]) as $col): ?>
-                        <th><?= htmlspecialchars($col) ?></th>
-                    <?php endforeach; ?>
-                </tr>
-                <?php foreach ($headers as $row): ?>
-                    <tr>
-                        <?php foreach ($row as $col): ?>
-                            <td><?= htmlspecialchars($col) ?></td>
-                        <?php endforeach; ?>
-                    </tr>
-                <?php endforeach; ?>
-            </table>
-        <?php else: ?>
-            <p>No se encontraron datos de cabecera.</p>
-        <?php endif; ?>
+                <?php if ($error): ?>
+                    <p><?= htmlspecialchars($error) ?></p>
+                <?php else: ?>
+                    <?php if ($headers): ?>
+                        <h4>Cabecera</h4>
+                        <div class="table-responsive">
+                            <table class="table table-striped table-bordered table-hover">
+                                <thead class="table-dark">
+                                    <tr>
+                                        <?php foreach ($columns as $col): ?>
+                                            <th><?= htmlspecialchars(ucwords(str_replace('_', ' ', $col))) ?></th>
+                                        <?php endforeach; ?>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <?php foreach ($headers as $row): ?>
+                                        <tr>
+                                            <?php foreach ($columns as $col): ?>
+                                                <td><?= htmlspecialchars($row[$col]) ?></td>
+                                            <?php endforeach; ?>
+                                        </tr>
+                                    <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                    <?php else: ?>
+                        <p>No se encontraron datos de cabecera.</p>
+                    <?php endif; ?>
 
-        <?php if ($config[$tipo][$modulo]['detail']): ?>
-            <p>No se mostrará información de detalle en este reporte.</p>
-        <?php endif; ?>
-    <?php endif; ?>
+                    <?php if ($config[$tipo][$modulo]['detail']): ?>
+                        <p>No se mostrará información de detalle en este reporte.</p>
+                    <?php endif; ?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Style report output with cards, responsive table, and Bootstrap enhancements
- Suppress non-record ID columns while displaying friendly headers

## Testing
- `php -l paginas/reportes/generar.php`


------
https://chatgpt.com/codex/tasks/task_e_6891eab44eac833392d7731905880ab7