### PR TITLE
Mostrar plan de pago en facturas a crédito

### DIFF
--- a/paginas/movimientos/ventas/facturacion/agregar.php
+++ b/paginas/movimientos/ventas/facturacion/agregar.php
@@ -102,7 +102,7 @@
       <!-- Botones -->
       <div class="row mt-4">
         <div class="col-md-6">
-          <button class="btn btn-success w-100" onclick="guardarFactura(); return false;">
+          <button class="btn btn-success w-100" onclick="preGuardarFactura(); return false;">
             <i class="bi bi-check-circle me-1"></i>Guardar
           </button>
         </div>
@@ -126,12 +126,20 @@
             </div>
             <div class="modal-body">
                 <div class="row">
+                    <div class="col-12 mb-2">
+                        <label>Total a pagar</label>
+                        <input type="text" id="pp-total" class="form-control" readonly>
+                    </div>
+                    <div class="col-12 mb-2">
+                        <label>Entrega</label>
+                        <input type="number" id="pp-entrega" class="form-control">
+                    </div>
                     <div class="col-6">
                         <label>Fecha Venc.</label>
                         <input type="date" id="pp-fecha" class="form-control">
                     </div>
                     <div class="col-6">
-                        <label>Monto</label>
+                        <label>Monto Cuota</label>
                         <input type="number" id="pp-monto" class="form-control">
                     </div>
                     <div class="col-12 mt-2">

--- a/vistas/factura.js
+++ b/vistas/factura.js
@@ -46,8 +46,6 @@ $(document).on("change", "#condicion", function () {
     if ($(this).val() === "CREDITO") {
         $("#tipo_pago_group").hide();
         $("#tipo_pago").val("0");
-//        let modal = new bootstrap.Modal(document.getElementById('modal-plan'));
-//        modal.show();
     } else {
         $("#tipo_pago_group").show();
     }
@@ -57,6 +55,21 @@ $(document).on("change", "#condicion", function () {
 //----------------------------------------------------
 //----------------------------------------------------
 $(document).on("click", "#pp-confirmar", function () {
+    $(".cuota-entrega").remove();
+    let entrega = quitarDecimalesConvertir($("#pp-entrega").val());
+    if (entrega > 0) {
+        $("#pp-detalle").prepend(`
+            <tr class="cuota-entrega">
+                <td>1</td>
+                <td>${$("#fecha").val()}</td>
+                <td>${formatearNumero(entrega)}</td>
+                <td><button class="btn btn-danger rem-cuota">Remover</button></td>
+            </tr>
+        `);
+    }
+    $("#pp-detalle tr").each(function (index) {
+        $(this).find("td:eq(0)").text(index + 1);
+    });
     guardarFactura();
 });
 
@@ -273,6 +286,25 @@ $(document).on("click", ".rem-item", function (evt) {
     $(this).closest("tr").remove();
     calcularTotalesFactura();
 });
+//-------------------------------------------------------------
+//-------------------------------------------------------------
+//-------------------------------------------------------------
+function preGuardarFactura() {
+    if ($("#condicion").val() === "CREDITO") {
+        const total = quitarDecimalesConvertir($("#t_exenta").text()) +
+                quitarDecimalesConvertir($("#t_iva5").text()) +
+                quitarDecimalesConvertir($("#t_iva10").text());
+        $("#pp-total").val(formatearNumero(total));
+        $("#pp-entrega").val("");
+        $("#pp-fecha").val("");
+        $("#pp-monto").val("");
+        let modal = new bootstrap.Modal(document.getElementById('modal-plan'));
+        modal.show();
+    } else {
+        guardarFactura();
+    }
+}
+
 //-------------------------------------------------------------
 //-------------------------------------------------------------
 //-------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Mostrar modal de plan de pago al guardar facturas a crédito
- Agregar total, entrega y cuotas en el modal para configurar pagos
- Registrar entrega como primera cuota antes de guardar la factura

## Testing
- `php -l paginas/movimientos/ventas/facturacion/agregar.php`
- `node --check vistas/factura.js`


------
https://chatgpt.com/codex/tasks/task_e_6891ebc78c78833394f755b5edfba66a