### PR TITLE
Fix cash-only invoicing

### DIFF
--- a/paginas/movimientos/ventas/facturacion/agregar.php
+++ b/paginas/movimientos/ventas/facturacion/agregar.php
@@ -18,19 +18,12 @@
           <label class="form-label">Timbrado</label>
           <input type="text" class="form-control" id="timbrado">
         </div>
-        <div class="col-md-3">
-          <label class="form-label">Condición</label>
-          <select id="condicion" class="form-select">
-            <option value="CONTADO">CONTADO</option>
-            <option value="CREDITO">CRÉDITO</option>
-          </select>
-        </div>
 
         <div class="col-md-6">
           <label class="form-label">Cliente</label>
           <select id="cliente" class="form-select"></select>
         </div>
-        <div class="col-md-6" id="tipo_pago_group">
+        <div class="col-md-6">
           <label class="form-label">Tipo de Pago</label>
           <select id="tipo_pago" class="form-select">
             <option value="0">Seleccione</option>
@@ -114,55 +107,5 @@
       </div>
     </div>
   </div>
-</div>
-
-
-<div class="modal fade" id="modal-plan" tabindex="-1" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">Plan de Pago</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="row">
-                    <div class="col-12 mb-2">
-                        <label>Total a pagar</label>
-                        <input type="text" id="pp-total" class="form-control" readonly>
-                    </div>
-                    <div class="col-12 mb-2">
-                        <label>Entrega</label>
-                        <input type="number" id="pp-entrega" class="form-control">
-                    </div>
-                    <div class="col-6">
-                        <label>Fecha Venc.</label>
-                        <input type="date" id="pp-fecha" class="form-control">
-                    </div>
-                    <div class="col-6">
-                        <label>Monto Cuota</label>
-                        <input type="number" id="pp-monto" class="form-control">
-                    </div>
-                    <div class="col-12 mt-2">
-                        <button class="btn btn-primary" id="pp-agregar">Agregar cuota</button>
-                    </div>
-                </div>
-                <table class="table table-bordered mt-3">
-                    <thead>
-                        <tr>
-                            <th>#</th>
-                            <th>Vencimiento</th>
-                            <th>Monto</th>
-                            <th>Operaciones</th>
-                        </tr>
-                    </thead>
-                    <tbody id="pp-detalle"></tbody>
-                </table>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
-                <button type="button" class="btn btn-primary" id="pp-confirmar">Confirmar</button>
-            </div>
-        </div>
-    </div>
 </div>
 


### PR DESCRIPTION
## Summary
- remove credit option and plan modal from invoice form
- always register invoices as cash and fix save button

## Testing
- `php -l paginas/movimientos/ventas/facturacion/agregar.php`
- `node --check vistas/factura.js`


------
https://chatgpt.com/codex/tasks/task_e_6891f67fce988333a4372da1c6d9b6e9