### PR TITLE
feat: add datatable to audit report

### DIFF
--- a/index.php
+++ b/index.php
@@ -71,6 +71,8 @@ $nombre = $_SESSION['usuario'] ?? null;
         <link href="
               https://cdn.jsdelivr.net/npm/sweetalert2@11.22.0/dist/sweetalert2.min.css
               " rel="stylesheet">
+        <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+        <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.bootstrap5.min.css">
     </head>
     <!--end::Head-->
     <!--begin::Body-->
@@ -896,6 +898,11 @@ $nombre = $_SESSION['usuario'] ?? null;
                                             sparkline3.render();
                 </script>
                 <script src="jquery-3.7.1.min.js"></script>
+                <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+                <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+                <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
+                <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.bootstrap5.min.js"></script>
+                <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.print.min.js"></script>
                 <script src="vistas/util.js"></script>
                 <script src="vistas/dashboard.js"></script>
                 <script src="vistas/cliente.js"></script>

--- a/paginas/reportes/auditoria.php
+++ b/paginas/reportes/auditoria.php
@@ -1,12 +1,9 @@
 <?php
 ?>
-<div id="auditoria-contenido" class="container mt-4">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h4 class="mb-0">Reporte de Auditoría</h4>
-        <button id="btn-imprimir" class="btn btn-secondary btn-sm">Imprimir</button>
-    </div>
+<div class="container mt-4">
+    <h4 class="mb-3">Reporte de Auditoría</h4>
     <div class="table-responsive">
-        <table class="table table-striped table-bordered">
+        <table id="auditoria_tb" class="table table-striped table-bordered">
             <thead class="table-dark">
                 <tr>
                     <th>#</th>
@@ -18,35 +15,7 @@
                     <th>Fecha</th>
                 </tr>
             </thead>
-            <tbody id="auditoria_tb"></tbody>
+            <tbody></tbody>
         </table>
     </div>
- </div>
-<script>
-document.getElementById('btn-imprimir').addEventListener('click', function () {
-    window.print();
-});
-</script>
-<style>
-@media print {
-    body * {
-        visibility: hidden;
-    }
-
-    #auditoria-contenido,
-    #auditoria-contenido * {
-        visibility: visible;
-    }
-
-    #auditoria-contenido {
-        position: absolute;
-        left: 0;
-        top: 0;
-        width: 100%;
-    }
-
-    #btn-imprimir {
-        display: none;
-    }
-}
-</style>
+</div>

--- a/vistas/auditoria.js
+++ b/vistas/auditoria.js
@@ -7,22 +7,47 @@ function mostrarAuditoria(){
 function cargarTablaAuditoria(){
     let data = ejecutarAjax("controladores/auditoria.php", "listar=1");
     if(data === "0"){
-        $("#auditoria_tb").html("");
-    }else{
-        let json_data = JSON.parse(data);
-        $("#auditoria_tb").html("");
-        json_data.map(function(item){
-            $("#auditoria_tb").append(`
-                <tr>
-                    <td>${item.id_auditoria}</td>
-                    <td>${item.usuario || ''}</td>
-                    <td>${item.accion}</td>
-                    <td>${item.tabla}</td>
-                    <td>${item.id_registro || ''}</td>
-                    <td>${item.detalles || ''}</td>
-                    <td>${item.fecha}</td>
-                </tr>
-            `);
+        if ($.fn.DataTable.isDataTable('#auditoria_tb')) {
+            $('#auditoria_tb').DataTable().clear().draw();
+        }
+        return;
+    }
+
+    let json_data = JSON.parse(data);
+    if ($.fn.DataTable.isDataTable('#auditoria_tb')) {
+        let tabla = $('#auditoria_tb').DataTable();
+        tabla.clear().rows.add(json_data).draw();
+    } else {
+        $('#auditoria_tb').DataTable({
+            data: json_data,
+            columns: [
+                { data: 'id_auditoria' },
+                { data: 'usuario' },
+                { data: 'accion' },
+                { data: 'tabla' },
+                { data: 'id_registro' },
+                { data: 'detalles' },
+                { data: 'fecha' }
+            ],
+            dom: 'Bfrtip',
+            buttons: [
+                {
+                    extend: 'print',
+                    text: 'Imprimir',
+                    titleAttr: 'Imprimir'
+                }
+            ],
+            language: {
+                sSearch: "Buscar: ",
+                sInfo: "Mostrando resultados del _START_ al _END_ de un total de _TOTAL_ registros",
+                sInfoFiltered: "(filtrado de entre _MAX_ registros)",
+                sZeroRecords: "No hay resultados",
+                sInfoEmpty: "No hay resultados",
+                oPaginate: {
+                    sNext: "Siguiente",
+                    sPrevious: "Anterior"
+                }
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- replace manual audit table with DataTables for built-in search and print
- load DataTables assets across the app to enable advanced table features

## Testing
- `php -l index.php`
- `php -l paginas/reportes/auditoria.php`
- `node --check vistas/auditoria.js && echo "node check ok"`


------
https://chatgpt.com/codex/tasks/task_e_6891fe32ba0c8333a2eed6399b4573a2